### PR TITLE
Fixing tiny unit test typo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
 <img  src="https://visitor-badge.glitch.me/badge?page_id=tinymanorg.tealish&right_color=teal" />
 <a href="https://github.com/tinymanorg/tealish/actions/workflows/tests.yml"><img src="https://github.com/tinymanorg/tealish/actions/workflows/tests.yml/badge.svg?branch=main" /></a>
-<a href="https://algorand.com"><img src="https://img.shields.io/badge/Read-Docs-gold.svg" /></a>
+<a href="https://tealish.readthedocs.io/en/latest/"><img src="https://img.shields.io/badge/Read-Docs-gold.svg" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 ![Tealish, A readable language for Algorand, Powered by Tinyman](img/tealish_header.png)
 
+<p align="center">
+<img  src="https://visitor-badge.glitch.me/badge?page_id=tinymanorg.tealish&right_color=teal" />
+<a href="https://github.com/tinymanorg/tealish/actions/workflows/tests.yml"><img src="https://github.com/tinymanorg/tealish/actions/workflows/tests.yml/badge.svg?branch=main" /></a>
+<a href="https://algorand.com"><img src="https://img.shields.io/badge/Read-Docs-gold.svg" /></a>
+</p>
 
-Tealish is a readable language for the Algorand Virtual Machine. It enables developers to write TEAL in a procedural style optimized for readability. 
+---
+
+Tealish is a readable language for the Algorand Virtual Machine. It enables developers to write TEAL in a procedural style optimized for readability.
 
 Tealish transpiles to Teal rather than compiling directly to AVM bytecode. The produced Teal is as close to handwritten idiomatic Teal as possible.
 The original source Tealish (including comments) is included as comments in the generated Teal.
 The generated Teal is intended to be readable and auditable.
 The generated Teal should not be surprising - the Tealish writer should be able to easily imagine the generated Teal.
 
-Tealish is not a general purpose programming language. It is designed specifically for writing contracts for the AVM, optimizing for common patterns. 
+Tealish is not a general purpose programming language. It is designed specifically for writing contracts for the AVM, optimizing for common patterns.
 
 ## Status
 Tealish has been used to write large production contracts but it is not currently considered Production Ready for general use. It may have unexpected behavior outside of the scenarios it has been used for until now.
@@ -126,8 +133,8 @@ end
 ```
 
 ## Design Goals
-Tealish is designed first and foremost to be a more readable version of Teal. 
-The biggest difference between Teal and Tealish is the stack is made implicit in Tealish instead of being explicit as in Teal. 
+Tealish is designed first and foremost to be a more readable version of Teal.
+The biggest difference between Teal and Tealish is the stack is made implicit in Tealish instead of being explicit as in Teal.
 
 Readability is achieved by the following:
 - Multiple operations on a single line

--- a/tests/test.py
+++ b/tests/test.py
@@ -257,7 +257,8 @@ class TestAssignment(unittest.TestCase):
         with self.assertRaises(CompileError) as e:
             _ = compile_min(["x = 1"])
         self.assertEqual(
-            e.exception.args[0], 'Var "x" not declared in current scope at line 1\n x = 1'
+            e.exception.args[0],
+            'Var "x" not declared in current scope at line 1\n x = 1',
         )
 
     def test_fail_invalid(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -257,7 +257,7 @@ class TestAssignment(unittest.TestCase):
         with self.assertRaises(CompileError) as e:
             _ = compile_min(["x = 1"])
         self.assertEqual(
-            e.exception.args[0], 'Var "x" not declared in current scope at line 1'
+            e.exception.args[0], 'Var "x" not declared in current scope at line 1\n x = 1'
         )
 
     def test_fail_invalid(self):


### PR DESCRIPTION
## Proposed changes 

- Fixes typo in unit test comparing exception message string in the unit test
- Adds a few tiny badges to readme header with links to docs, visitors badge counter and link to ci pipeline status on main branch (hope you folks like it but let me know if you prefer no html in markdown files)