### PR TITLE
Adding type hints

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+[mypy-algosdk.*]
+ignore_missing_imports = True
+
+[mypy-textx.*]
+ignore_missing_imports = True

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -1,16 +1,18 @@
+from typing import List, Dict, Tuple, Optional, Any, Union
 from .nodes import Program
 from .utils import TealishMap
 
+from .base import BaseNode
 
 class TealWriter:
     def __init__(self) -> None:
-        self.level = 0
+        self.level: int = 0
         self.output = []
         self.source_map = {}
         self.current_output_line = 1
         self.current_input_line = 1
 
-    def write(self, parent, node_or_teal):
+    def write(self, parent, node_or_teal: Union[BaseNode, str]):
         parent._teal = []
         if hasattr(node_or_teal, "write_teal"):
             node = node_or_teal
@@ -37,7 +39,7 @@ class TealishCompiler:
         self.current_output_line = 1
         self.level = 0
         self.line_no = 0
-        self.nodes = []
+        self.nodes: List[BaseNode] = []
         self.conditional_count = 0
         self.error_messages = {}
         self.max_slot = 0
@@ -95,7 +97,7 @@ class TealishCompiler:
             for n in node.nodes:
                 self.traverse(n, visitor)
 
-    def reformat(self, formatter=None):
+    def reformat(self, formatter=None)->str:
         if not self.nodes:
             self.parse()
         if not self.processed:
@@ -109,14 +111,14 @@ class TealishCompiler:
         return map
 
 
-def compile_program(source):
+def compile_program(source: str):
     source_lines = source.split("\n")
     compiler = TealishCompiler(source_lines)
     teal = compiler.compile()
     return teal, compiler.get_map()
 
 
-def compile_lines(source_lines):
+def compile_lines(source_lines: List[str]):
     compiler = TealishCompiler(source_lines)
     compiler.parse()
     compiler.compile()
@@ -124,7 +126,7 @@ def compile_lines(source_lines):
     return teal_lines
 
 
-def reformat_program(source):
+def reformat_program(source: str):
     source_lines = source.split("\n")
     compiler = TealishCompiler(source_lines)
     output = compiler.reformat()

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Callable, Optional, Union, Tuple
+from typing import List, Dict, Callable, Union, Tuple
 from .base import BaseNode
 from .nodes import Node, Program
 from .utils import TealishMap

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -101,12 +101,12 @@ class TealishCompiler:
             for n in node.nodes:
                 self.traverse(n, visitor)
 
-    def reformat(self, formatter=None) -> str:
+    def reformat(self) -> str:
         if not self.nodes:
             self.parse()
         if not self.processed:
             self.process()
-        return self.nodes[0].tealish(formatter)
+        return self.nodes[0].tealish()
 
     def get_map(self):
         map = TealishMap()

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -45,7 +45,7 @@ class TealishCompiler:
         self.line_no = 0
         self.nodes: List[Node] = []
         self.conditional_count = 0
-        self.error_messages: Dict[str, str] = {}
+        self.error_messages: Dict[int, str] = {}
         self.max_slot = 0
         self.writer = TealWriter()
         self.processed = False

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -28,11 +28,11 @@ class TealWriter:
             if hasattr(parent, "line_no"):
                 self.current_input_line = parent.line_no
             self.source_map[self.current_output_line] = self.current_input_line
-            # TODO: should be `line_no`?
-            # parent.teal_line_no = self.current_output_line
             self.current_output_line += 1
         else:
-            raise Exception("wat?")
+            raise Exception(
+                "Expected BaseNode or str type as second argument of `write` function"
+            )
 
 
 class TealishCompiler:

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Optional, Any, Union
+from typing import List, Dict, Union
 from .base import BaseNode
 from .nodes import Node, Program
 from .utils import TealishMap

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -50,16 +50,19 @@ class TealishCompiler:
         self.writer = TealWriter()
         self.processed = False
 
-    def consume_line(self) -> Optional[str]:
+    def consume_line(self) -> str:
         if self.line_no == len(self.source_lines):
-            return None
+            # TODO: this and the func below are Optional[str] but nodes.py uses them heavily and dont
+            # check the type is not None
+            return  # type: ignore
         line = self.source_lines[self.line_no].strip()
         self.line_no += 1
         return line
 
-    def peek(self) -> Optional[str]:
+    def peek(self) -> str:
         if self.line_no == len(self.source_lines):
-            return None
+            # TODO: see above
+            return  # type: ignore
         return self.source_lines[self.line_no].strip()
 
     def write(self, lines: Union[str, List[str]] = "", line_no: int = 0) -> None:

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Callable, Union, Tuple
+from typing import List, Dict, Union, Tuple
 from .base import BaseNode
 from .nodes import Node, Program
 from .utils import TealishMap
@@ -52,7 +52,8 @@ class TealishCompiler:
 
     def consume_line(self) -> str:
         if self.line_no == len(self.source_lines):
-            # TODO: this and the func below are Optional[str] but nodes.py uses them heavily and dont
+            # TODO: this and the func below are Optional[str] but
+            # nodes.py uses them heavily and dont
             # check the type is not None
             return  # type: ignore
         line = self.source_lines[self.line_no].strip()
@@ -95,19 +96,6 @@ class TealishCompiler:
         self.output = self.writer.output
         return self.writer.output
 
-    def traverse(
-        self, node: BaseNode, visitor: Callable[[BaseNode], None] = None
-    ) -> None:
-        if node is None:
-            node = self.nodes[0]
-        if visitor:
-            visitor(node)
-        # TODO: Note i changed this from getattr
-        if hasattr(node, "nodes"):
-            # TODO: still complains about BaseNode not having `nodes`
-            for n in node.nodes:  # type: ignore
-                self.traverse(n, visitor)
-
     def reformat(self) -> str:
         if not self.nodes:
             self.parse()
@@ -118,8 +106,7 @@ class TealishCompiler:
     def get_map(self) -> TealishMap:
         map = TealishMap()
         map.teal_tealish = dict(self.source_map)
-        # TODO:
-        map.errors = dict(self.error_messages)  # type: ignore
+        map.errors = dict(self.error_messages)
         return map
 
 

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,27 +1,30 @@
-from typing import List
+from typing import List, Dict, TYPE_CHECKING
 from tealish.errors import CompileError
 from .tealish_builtins import constants
 from .langspec import get_active_langspec
 
+
+if TYPE_CHECKING:
+    from .nodes import Block
 
 lang_spec = get_active_langspec()
 
 structs = {}
 
 
-def lookup_op(name):
+def lookup_op(name: str):
     if name not in lang_spec.ops:
         raise KeyError(f'Op "{name}" does not exist!')
     return lang_spec.ops[name]
 
 
-def lookup_constant(name):
+def lookup_constant(name: str):
     if name not in constants:
         raise KeyError(f'Constant "{name}" does not exist!')
     return constants[name]
 
 
-def get_field_type(namespace, name):
+def get_field_type(namespace: Dict[str, str], name: str):
     if "txn" in namespace:
         return lang_spec.txn_fields[name]
     elif namespace == "global":
@@ -144,7 +147,7 @@ class BaseNode:
             blocks.update(s["blocks"])
         return blocks
 
-    def get_block(self, name):
+    def get_block(self, name) -> "Block":
         block = self.get_blocks().get(name)
         # if block:
         #     self.used_blocks.add(block.label)

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import cast, Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from tealish.errors import CompileError
 from .tealish_builtins import constants
 from .langspec import get_active_langspec
@@ -149,7 +149,7 @@ class BaseNode:
                     return i
         raise Exception("No available slots!")
 
-    def get_blocks(self) -> dict[str, "Block"]:
+    def get_blocks(self) -> Dict[str, "Block"]:
         blocks = {}
         for s in self.get_scopes():
             blocks.update(s["blocks"])
@@ -162,15 +162,15 @@ class BaseNode:
         return self.find_parent(node_class) is not None
 
     # TODO: also suffers from `parent` not being defined"
-    def find_parent(self, node_class: type["Node"]) -> Optional["Node"]:
-        p = self.parent  # type: ignore
+    def find_parent(self, node_class: type) -> Optional["Node"]:
+        p: Optional["Node"] = self.parent  # type: ignore
         while p:
             if isinstance(p, node_class):
-                return p
+                return cast(Node, p)
             p = p.parent  # type: ignore
         return None
 
-    def has_child_node(self, node_class: type["Node"]) -> bool:
+    def has_child_node(self, node_class: type) -> bool:
         # TODO: Only available on Node and other subclasses
         for node in self.nodes:  # type: ignore
             if isinstance(node, node_class) or node.has_child_node(node_class):  # type: ignore
@@ -215,7 +215,7 @@ class BaseNode:
     def lookup_constant(self, name: str) -> Tuple[str, int]:
         return lookup_constant(name)
 
-    def define_struct(self, struct_name: str, struct: dict[str, Any]) -> None:
+    def define_struct(self, struct_name: str, struct: Dict[str, Any]) -> None:
         structs[struct_name] = struct
 
     def get_struct(self, struct_name: str) -> Dict[str, Any]:

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict, Tuple, TYPE_CHECKING
+from typing import Any, List, Dict, Tuple, Union, TYPE_CHECKING
 from tealish.errors import CompileError
 from .tealish_builtins import constants
 from .langspec import get_active_langspec
@@ -108,7 +108,7 @@ class BaseNode:
         else:
             return (None, None)
 
-    def declare_var(self, name: str, type: str | tuple[str, str]) -> int:
+    def declare_var(self, name: str, type: Union[str, Tuple[str, str]]) -> int:
         slot, _ = self.get_var(name)
         if slot is not None:
             raise Exception(f'Redefinition of variable "{name}"')

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -166,7 +166,7 @@ class BaseNode:
         p: Optional["Node"] = self.parent  # type: ignore
         while p:
             if isinstance(p, node_class):
-                return cast(Node, p)
+                return cast("Node", p)
             p = p.parent  # type: ignore
         return None
 

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,3 +1,4 @@
+from typing import List
 from tealish.errors import CompileError
 from .tealish_builtins import constants
 from .langspec import get_active_langspec
@@ -38,6 +39,9 @@ def check_arg_types(name, args):
 
 
 class BaseNode:
+
+    _teal: List[str]
+
     def process(self):
         pass
 

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -58,10 +58,7 @@ class BaseNode:
         raise NotImplementedError()
 
     def tealish(self):
-        output = self._tealish(formatter)
-        if formatter:
-            output = formatter(self, output)
-        return output
+        return self._tealish()
 
     def get_scope(self):
         scope = {

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -78,7 +78,7 @@ class BaseNode:
             scope["functions"].update(s["functions"])
         return scope
 
-    def get_scopes(self) -> list[Dict[str, Dict[str, Any]]]:
+    def get_scopes(self) -> List[Dict[str, Dict[str, Any]]]:
         scopes = []
         s = self.get_current_scope()
         while True:
@@ -205,7 +205,7 @@ class BaseNode:
             raise KeyError(f'Var "{name}" not declared in current scope')
         return scope["slots"][name]
 
-    def lookup_const(self, name: str) -> str:
+    def lookup_const(self, name: str) -> Tuple[str, int]:
         scope = self.get_scope()
         if name not in scope["consts"]:
             raise KeyError(f'Const "{name}" not declared in current scope')

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -89,7 +89,7 @@ class BaseNode:
                 break
         return scopes
 
-    def get_const(self, name: str) -> Constant:
+    def get_const(self, name: str) -> "Constant":
         consts = {}
         for s in self.get_scopes():
             consts.update(s["consts"])

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -54,10 +54,10 @@ class BaseNode:
     def write_teal(self, writer):
         raise NotImplementedError(self)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         raise NotImplementedError()
 
-    def tealish(self, formatter=None):
+    def tealish(self):
         output = self._tealish(formatter)
         if formatter:
             output = formatter(self, output)

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from tealish.errors import CompileError
 from .tealish_builtins import constants
 from .langspec import get_active_langspec
@@ -7,7 +7,7 @@ from .langspec import get_active_langspec
 if TYPE_CHECKING:
     from . import TealWriter
     from .expression_nodes import Constant
-    from .nodes import Block
+    from .nodes import Block, Node
 
 lang_spec = get_active_langspec()
 
@@ -35,13 +35,13 @@ def get_field_type(namespace: str, name: str) -> str:
         raise Exception(f"Unknown name in namespace {name}")
 
 
-def check_arg_types(name: str, args: List["BaseNode"]) -> None:
+def check_arg_types(name: str, args: List["Node"]) -> None:
     op = lookup_op(name)
     arg_types = op["arg_types"]
     for i, arg in enumerate(args):
-        if arg.type != "any" and arg_types[i] != "any" and arg.type != arg_types[i]:
+        if arg.type != "any" and arg_types[i] != "any" and arg.type != arg_types[i]:  # type: ignore
             raise Exception(
-                f"Incorrect type {arg.type} for arg {i} of {name}. Expected {arg_types[i]}"
+                f"Incorrect type {arg.type} for arg {i} of {name}. Expected {arg_types[i]}"  # type: ignore
             )
 
 
@@ -101,7 +101,7 @@ class BaseNode:
             slots.update(s["slots"])
         return slots
 
-    def get_var(self, name):
+    def get_var(self, name: str) -> Tuple[Any, Any]:
         slots = self.get_slots()
         if name in slots:
             return slots[name]
@@ -121,16 +121,16 @@ class BaseNode:
         if "func__" in scope["name"]:
             # If this var is declared in a function then use the global max slot + 1
             # This is to prevent functions using overlapping slots
-            slot = self.compiler.max_slot + 1
+            slot = self.compiler.max_slot + 1  # type: ignore
         else:
             slot = self.find_slot()
 
         # TODO: same issue here with compiler
-        self.compiler.max_slot = max(self.compiler.max_slot, slot)
+        self.compiler.max_slot = max(self.compiler.max_slot, slot)  # type: ignore
         scope["slots"][name] = [slot, type]
         return slot
 
-    def del_var(self, name):
+    def del_var(self, name: str) -> None:
         scope = self.get_current_scope()
         if name in scope["slots"]:
             del scope["slots"][name]
@@ -161,31 +161,31 @@ class BaseNode:
     def is_descendant_of(self, node_class: type) -> bool:
         return self.find_parent(node_class) is not None
 
-    # TODO: also suffers from `parent` not being defined
-    def find_parent(self, node_class):
-        p = self.parent
+    # TODO: also suffers from `parent` not being defined"
+    def find_parent(self, node_class: type["Node"]) -> Optional["Node"]:
+        p = self.parent  # type: ignore
         while p:
             if isinstance(p, node_class):
                 return p
-            p = p.parent
+            p = p.parent  # type: ignore
         return None
 
-    def has_child_node(self, node_class):
+    def has_child_node(self, node_class: type["Node"]) -> bool:
         # TODO: Only available on Node and other subclasses
-        for node in self.nodes:
-            if isinstance(node, node_class) or node.has_child_node(node_class):
+        for node in self.nodes:  # type: ignore
+            if isinstance(node, node_class) or node.has_child_node(node_class):  # type: ignore
                 return True
         return False
 
     def get_current_scope(self) -> Dict[str, Any]:
         # TODO: Only available on Node and other subclasses
-        return self.parent.get_current_scope()
+        return self.parent.get_current_scope()  # type: ignore
 
-    def check_arg_types(self, name, args):
+    def check_arg_types(self, name: str, args: List["Node"]) -> None:
         try:
             return check_arg_types(name, args)
         except Exception as e:
-            raise CompileError(str(e), node=self)
+            raise CompileError(str(e), node=self)  # type: ignore
 
     def get_field_type(self, namespace: str, name: str) -> str:
         return get_field_type(namespace, name)
@@ -193,13 +193,13 @@ class BaseNode:
     def lookup_op(self, name: str) -> Dict[str, Any]:
         return lookup_op(name)
 
-    def lookup_func(self, name):
+    def lookup_func(self, name: str) -> Any:
         scope = self.get_scope()
         if name not in scope["functions"]:
             raise KeyError(f'Func "{name}" not declared in current scope')
         return scope["functions"][name]
 
-    def lookup_var(self, name):
+    def lookup_var(self, name: str) -> Any:
         scope = self.get_scope()
         if name not in scope["slots"]:
             raise KeyError(f'Var "{name}" not declared in current scope')
@@ -218,7 +218,7 @@ class BaseNode:
     def define_struct(self, struct_name: str, struct: dict[str, Any]) -> None:
         structs[struct_name] = struct
 
-    def get_struct(self, struct_name) -> Dict[str, Any]:
+    def get_struct(self, struct_name: str) -> Dict[str, Any]:
         return structs[struct_name]
 
     # TODO: these attributes are only available on Node and other children types
@@ -226,15 +226,15 @@ class BaseNode:
     @property
     def line_no(self) -> int:
         if hasattr(self, "_line_no"):
-            return self._line_no
+            return self._line_no  # type: ignore
         if hasattr(self, "parent"):
-            return self.parent.line_no
+            return self.parent.line_no  # type: ignore
         raise Exception("No line number or parent line number available")
 
     @property
     def line(self) -> str:
         if hasattr(self, "_line"):
-            return self._line
+            return self._line  # type: ignore
         if hasattr(self, "parent"):
-            return self.parent.line
+            return self.parent.line  # type: ignore
         raise Exception("No line or parent line available")

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -114,6 +114,10 @@ class BaseNode:
             raise Exception(f'Redefinition of variable "{name}"')
 
         scope = self.get_current_scope()
+
+        # TODO: is this used in place of a type check? If we can do an isinstance check to
+        # something that has `compiler` defined, we can be more certain the `compiler` attribute
+        # is defined
         if "func__" in scope["name"]:
             # If this var is declared in a function then use the global max slot + 1
             # This is to prevent functions using overlapping slots
@@ -121,6 +125,7 @@ class BaseNode:
         else:
             slot = self.find_slot()
 
+        # TODO: same issue here with compiler
         self.compiler.max_slot = max(self.compiler.max_slot, slot)
         scope["slots"][name] = [slot, type]
         return slot
@@ -156,6 +161,7 @@ class BaseNode:
     def is_descendant_of(self, node_class: type) -> bool:
         return self.find_parent(node_class) is not None
 
+    # TODO: also suffers from `parent` not being defined
     def find_parent(self, node_class):
         p = self.parent
         while p:
@@ -165,12 +171,14 @@ class BaseNode:
         return None
 
     def has_child_node(self, node_class):
+        # TODO: Only available on Node and other subclasses
         for node in self.nodes:
             if isinstance(node, node_class) or node.has_child_node(node_class):
                 return True
         return False
 
     def get_current_scope(self) -> Dict[str, Any]:
+        # TODO: Only available on Node and other subclasses
         return self.parent.get_current_scope()
 
     def check_arg_types(self, name, args):
@@ -213,6 +221,8 @@ class BaseNode:
     def get_struct(self, struct_name) -> Dict[str, Any]:
         return structs[struct_name]
 
+    # TODO: these attributes are only available on Node and other children types
+    # we should either define them here or something else?
     @property
     def line_no(self) -> int:
         if hasattr(self, "_line_no"):

--- a/tealish/build.py
+++ b/tealish/build.py
@@ -2,8 +2,8 @@ from base64 import b64decode
 from typing import Tuple
 import json
 import subprocess
-from algosdk.v2client.algod import AlgodClient  # type: ignore
-from algosdk.source_map import SourceMap  # type: ignore
+from algosdk.v2client.algod import AlgodClient
+from algosdk.source_map import SourceMap
 
 
 def assemble_with_goal(teal: str) -> Tuple[bytes, SourceMap]:

--- a/tealish/build.py
+++ b/tealish/build.py
@@ -1,8 +1,8 @@
 from base64 import b64decode
 import json
 import subprocess
-from algosdk.v2client.algod import AlgodClient
-from algosdk.source_map import SourceMap
+from algosdk.v2client.algod import AlgodClient  # type: ignore
+from algosdk.source_map import SourceMap  # type: ignore
 
 
 def assemble_with_goal(teal):

--- a/tealish/build.py
+++ b/tealish/build.py
@@ -1,11 +1,12 @@
 from base64 import b64decode
+from typing import Tuple
 import json
 import subprocess
 from algosdk.v2client.algod import AlgodClient  # type: ignore
 from algosdk.source_map import SourceMap  # type: ignore
 
 
-def assemble_with_goal(teal):
+def assemble_with_goal(teal: str) -> Tuple[bytes, SourceMap]:
     tmp_out_filename = "/tmp/out.tok"
     try:
         subprocess.check_output(
@@ -21,7 +22,7 @@ def assemble_with_goal(teal):
     return bytecode, SourceMap(algod_sourcemap)
 
 
-def assemble_with_algod(teal, algod_url):
+def assemble_with_algod(teal: str, algod_url: str) -> Tuple[bytes, SourceMap]:
     token = ""
     if "#" in algod_url:
         algod_url, token = algod_url.split("#")

--- a/tealish/cli.py
+++ b/tealish/cli.py
@@ -202,7 +202,9 @@ def langspec_diff(url: str) -> None:
     else:
         local_name = "./langspec.json"
         base_langspec = packaged_lang_spec
-        new_langspec = local_lang_spec
+        new_langspec = packaged_lang_spec
+        if local_lang_spec is not None:
+            new_langspec = local_lang_spec
 
     new_ops = new_langspec.new_ops(base_langspec)
     if new_ops:

--- a/tealish/cli.py
+++ b/tealish/cli.py
@@ -152,14 +152,6 @@ def format(ctx: click.Context, tealish_file: IO) -> None:
     tealish_file.truncate()
 
 
-@click.command()
-@click.argument("tealish_file", type=click.File("r"))
-@click.pass_context
-def html(ctx: click.Context, tealish_file: IO) -> None:
-    """Output HTML of Tealish & Teal source"""
-    raise NotImplementedError()
-
-
 @click.group()
 def langspec() -> None:
     """Tools to support new Teal versions by updating the langspec file"""
@@ -169,7 +161,10 @@ def langspec() -> None:
 @click.command()
 @click.pass_context
 def langspec_update(ctx: click.Context) -> None:
-    """Support new Teal opcodes by updating the langspec.json file from go-algorand master branch"""
+    """
+    Support new Teal opcodes by updating the langspec.json file
+    from go-algorand master branch
+    """
     ctx.invoke(langspec_fetch, url_or_branch="master")
 
 
@@ -177,7 +172,10 @@ def langspec_update(ctx: click.Context) -> None:
 @click.argument("url_or_branch", type=str)
 @click.pass_context
 def langspec_fetch(ctx: click.Context, url_or_branch: str) -> None:
-    """Fetch a specific langspec.json file and use it for the current project. Can be a URL or branch name of go-algorand"""
+    """
+    Fetch a specific langspec.json file and use it for the current project.
+    Can be a URL or branch name of go-algorand
+    """
     new_langspec = fetch_langspec(url_or_branch)
     with open("langspec.json", "w") as f:
         json.dump(new_langspec.as_dict(), f)
@@ -193,7 +191,10 @@ def langspec_fetch(ctx: click.Context, url_or_branch: str) -> None:
 @click.command()
 @click.argument("url", type=str, default="")
 def langspec_diff(url: str) -> None:
-    """Show the differences between the current local langspec.json file and the one packaged with this version Tealish"""
+    """
+    Show the differences between the current local langspec.json
+    file and the one packaged with this version Tealish
+    """
 
     if url:
         local_name = url
@@ -221,5 +222,4 @@ langspec.add_command(langspec_diff, "diff")
 cli.add_command(compile)
 cli.add_command(build)
 cli.add_command(format)
-cli.add_command(html)
 cli.add_command(langspec)

--- a/tealish/cli.py
+++ b/tealish/cli.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import click
+from typing import List, Optional, Tuple, IO
 from tealish import compile_program, reformat_program
 from tealish.errors import CompileError, ParseError
 from tealish.langspec import (
@@ -10,13 +11,22 @@ from tealish.langspec import (
     local_lang_spec,
 )
 from tealish.build import assemble_with_goal, assemble_with_algod
+from tealish.utils import TealishMap
 
 
-def _build(path, assembler=None, algod_url=None, quiet=False) -> None:
+def _build(
+    path: pathlib.Path,
+    assembler: Optional[str] = None,
+    algod_url: Optional[str] = None,
+    quiet: bool = False,
+) -> None:
+
+    paths: List[pathlib.Path]
     if path.is_dir():
-        paths = path.glob("*.tl")
+        paths = list(path.glob("*.tl"))
     else:
         paths = [path]
+
     for path in paths:
         output_path = pathlib.Path(path).parent / "build"
         output_path.mkdir(exist_ok=True)
@@ -49,6 +59,11 @@ def _build(path, assembler=None, algod_url=None, quiet=False) -> None:
                         f"Assembling {teal_filename} to {tok_filename} using algod ({algod_url})"
                     )
                 try:
+                    if algod_url is None:
+                        raise Exception(
+                            "algod assembler specified but algod_url is None"
+                        )
+
                     bytecode, sourcemap = assemble_with_algod(teal_string, algod_url)
                 except Exception as e:
                     raise click.ClickException(str(e))
@@ -67,20 +82,20 @@ def _build(path, assembler=None, algod_url=None, quiet=False) -> None:
                 f.write(json.dumps(tealish_map.as_dict()).replace("],", "],\n"))
 
 
-def _compile_program(source):
+def _compile_program(source: str) -> Tuple[List[str], TealishMap]:
     try:
         teal, map = compile_program(source)
     except ParseError as e:
-        raise click.ClickException(e)
+        raise click.ClickException(str(e))
     except CompileError as e:
-        raise click.ClickException(e)
+        raise click.ClickException(str(e))
     return teal, map
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option("--quiet", "-q", is_flag=True, help="Only print warnings and errors")
 @click.pass_context
-def cli(ctx, quiet):
+def cli(ctx: click.Context, quiet: bool) -> None:
     "Tealish Compiler & Tools"
     ctx.ensure_object(dict)
     ctx.obj["quiet"] = quiet
@@ -89,7 +104,7 @@ def cli(ctx, quiet):
 @click.command()
 @click.argument("path", type=click.Path(exists=True, path_type=pathlib.Path))
 @click.pass_context
-def compile(ctx, path):
+def compile(ctx: click.Context, path: pathlib.Path) -> None:
     """Compile .tl to .teal"""
     _build(path, assembler=None, quiet=ctx.obj["quiet"])
 
@@ -115,7 +130,9 @@ def compile(ctx, path):
     help="Algod URL to use for compiling TEAL",
 )
 @click.pass_context
-def build(ctx, path, assembler, algod_url):
+def build(
+    ctx: click.Context, path: pathlib.Path, assembler: str, algod_url: str
+) -> None:
     """Compile .tl to .teal & assemble .teal to .tok (bytecode) & output sourcemap"""
     _build(path, assembler=assembler, algod_url=algod_url, quiet=ctx.obj["quiet"])
 
@@ -123,13 +140,13 @@ def build(ctx, path, assembler, algod_url):
 @click.command()
 @click.argument("tealish_file", type=click.File("r+"))
 @click.pass_context
-def format(ctx, tealish_file):
+def format(ctx: click.Context, tealish_file: IO) -> None:
     """Rewrite .tl file using standard tealish style"""
     input = tealish_file.read()
     try:
         output = reformat_program(input)
     except ParseError as e:
-        raise click.ClickException(e)
+        raise click.ClickException(str(e))
     tealish_file.seek(0)
     tealish_file.write(output)
     tealish_file.truncate()
@@ -138,20 +155,20 @@ def format(ctx, tealish_file):
 @click.command()
 @click.argument("tealish_file", type=click.File("r"))
 @click.pass_context
-def html(ctx, tealish_file):
+def html(ctx: click.Context, tealish_file: IO) -> None:
     """Output HTML of Tealish & Teal source"""
     raise NotImplementedError()
 
 
 @click.group()
-def langspec():
+def langspec() -> None:
     """Tools to support new Teal versions by updating the langspec file"""
     pass
 
 
 @click.command()
 @click.pass_context
-def langspec_update(ctx):
+def langspec_update(ctx: click.Context) -> None:
     """Support new Teal opcodes by updating the langspec.json file from go-algorand master branch"""
     ctx.invoke(langspec_fetch, url_or_branch="master")
 
@@ -159,7 +176,7 @@ def langspec_update(ctx):
 @click.command()
 @click.argument("url_or_branch", type=str)
 @click.pass_context
-def langspec_fetch(ctx, url_or_branch):
+def langspec_fetch(ctx: click.Context, url_or_branch: str) -> None:
     """Fetch a specific langspec.json file and use it for the current project. Can be a URL or branch name of go-algorand"""
     new_langspec = fetch_langspec(url_or_branch)
     with open("langspec.json", "w") as f:
@@ -175,7 +192,7 @@ def langspec_fetch(ctx, url_or_branch):
 
 @click.command()
 @click.argument("url", type=str, default="")
-def langspec_diff(url):
+def langspec_diff(url: str) -> None:
     """Show the differences between the current local langspec.json file and the one packaged with this version Tealish"""
 
     if url:

--- a/tealish/cli.py
+++ b/tealish/cli.py
@@ -12,7 +12,7 @@ from tealish.langspec import (
 from tealish.build import assemble_with_goal, assemble_with_algod
 
 
-def _build(path, assembler=None, algod_url=None, quiet=False):
+def _build(path, assembler=None, algod_url=None, quiet=False) -> None:
     if path.is_dir():
         paths = path.glob("*.tl")
     else:
@@ -42,7 +42,7 @@ def _build(path, assembler=None, algod_url=None, quiet=False):
                 try:
                     bytecode, sourcemap = assemble_with_goal(teal_string)
                 except Exception as e:
-                    raise click.ClickException(e)
+                    raise click.ClickException(str(e))
             elif assembler == "algod":
                 if not quiet:
                     click.echo(
@@ -51,7 +51,7 @@ def _build(path, assembler=None, algod_url=None, quiet=False):
                 try:
                     bytecode, sourcemap = assemble_with_algod(teal_string, algod_url)
                 except Exception as e:
-                    raise click.ClickException(e)
+                    raise click.ClickException(str(e))
             elif assembler == "sandbox":
                 raise click.ClickException("Sandbox is not supported yet.")
             else:

--- a/tealish/errors.py
+++ b/tealish/errors.py
@@ -1,9 +1,15 @@
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .nodes import Node
+
+
 class ParseError(Exception):
     pass
 
 
 class CompileError(Exception):
-    def __init__(self, message: str, node=None) -> None:
+    def __init__(self, message: str, node: Optional["Node"] = None) -> None:
         self.node = node
         if node and getattr(node, "line_no", None):
             message += f" at line {node.line_no}\n"

--- a/tealish/errors.py
+++ b/tealish/errors.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .nodes import Node
+    from .base import BaseNode
 
 
 class ParseError(Exception):
@@ -9,7 +9,7 @@ class ParseError(Exception):
 
 
 class CompileError(Exception):
-    def __init__(self, message: str, node: Optional["Node"] = None) -> None:
+    def __init__(self, message: str, node: Optional["BaseNode"] = None) -> None:
         self.node = node
         if node and getattr(node, "line_no", None):
             message += f" at line {node.line_no}\n"

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -85,7 +85,7 @@ class Constant(BaseNode):
 
 
 class UnaryOp(BaseNode):
-    def __init__(self, op, a, parent=None) -> None:
+    def __init__(self, op, a: BaseNode, parent=None) -> None:
         self.a = a
         self.op = op
         self.nodes = [a]
@@ -457,7 +457,7 @@ class StructField(BaseNode):
         return f"{self.name}.{self.field}"
 
 
-def class_provider(name):
+def class_provider(name: str):
     classes = {
         "Variable": Variable,
         "Constant": Constant,

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -1,39 +1,45 @@
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from .base import BaseNode
 from .errors import CompileError
 
 
+if TYPE_CHECKING:
+    from . import TealWriter
+    from .nodes import Node, GenericExpression
+
+
 class Integer(BaseNode):
-    def __init__(self, value, parent=None) -> None:
+    def __init__(self, value: str, parent: Optional[BaseNode] = None) -> None:
         self.value = int(value)
         self.type = "int"
         self.parent = parent
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushint {self.value}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"pushint {self.value}"
 
 
 class Bytes(BaseNode):
-    def __init__(self, value, parent=None) -> None:
+    def __init__(self, value: str, parent: Optional[BaseNode] = None) -> None:
         self.value = value
         self.type = "bytes"
         self.parent = parent
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f'pushbytes "{self.value}"')
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f'"{self.value}"'
 
 
 class Variable(BaseNode):
-    def __init__(self, name, parent=None) -> None:
+    def __init__(self, name: str, parent: Optional[BaseNode] = None) -> None:
         self.name = name
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         try:
             self.slot, self.type = self.lookup_var(self.name)
         except KeyError as e:
@@ -43,20 +49,20 @@ class Variable(BaseNode):
             if self.type[0] == "struct":
                 self.type = "bytes"
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"load {self.slot} // {self.name}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"{self.name}"
 
 
 class Constant(BaseNode):
-    def __init__(self, name, parent=None) -> None:
+    def __init__(self, name: str, parent: Optional[BaseNode] = None) -> None:
         self.name = name
-        self.type = None
+        self.type: str = ""
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         type, value = None, None
         try:
             # user defined const
@@ -71,123 +77,136 @@ class Constant(BaseNode):
                 )
         if type not in ("int", "bytes"):
             raise CompileError(f"Unexpected const type {type}", node=self)
+
         self.type = type
         self.value = value
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         if self.type == "int":
             writer.write(self, f"pushint {self.value} // {self.name}")
         elif self.type == "bytes":
             writer.write(self, f"pushbytes {self.value} // {self.name}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"{self.name}"
 
 
 class UnaryOp(BaseNode):
-    def __init__(self, op, a: BaseNode, parent=None) -> None:
+    def __init__(self, op: str, a: "Node", parent: Optional[BaseNode] = None) -> None:
         self.a = a
         self.op = op
         self.nodes = [a]
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.a.process()
         self.check_arg_types(self.op, [self.a])
         op = self.lookup_op(self.op)
         self.type = {"B": "bytes", "U": "int", ".": "any"}[op.get("Returns", "")]
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.a)
         writer.write(self, f"{self.op}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"{self.op}{self.a.tealish()}"
 
 
 class BinaryOp(BaseNode):
-    def __init__(self, a, b, op, parent=None) -> None:
+    def __init__(
+        self, a: "Node", b: "Node", op: str, parent: Optional[BaseNode] = None
+    ) -> None:
         self.a = a
         self.b = b
         self.op = op
         self.nodes = [a, b]
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.a.process()
         self.b.process()
         self.check_arg_types(self.op, [self.a, self.b])
         op = self.lookup_op(self.op)
         self.type = {"B": "bytes", "U": "int", ".": "any"}[op.get("Returns", "")]
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.a)
         writer.write(self, self.b)
         writer.write(self, f"{self.op}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"{self.a.tealish()} {self.op} {self.b.tealish()}"
 
 
 class Group(BaseNode):
-    def __init__(self, expression, parent=None) -> None:
+    def __init__(
+        self, expression: "GenericExpression", parent: Optional[BaseNode] = None
+    ) -> None:
         self.expression = expression
         self.nodes = [expression]
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.expression.process()
         self.type = self.expression.type
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.expression)
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"({self.expression.tealish()})"
 
 
 class FunctionCall(BaseNode):
-    def __init__(self, name, args, parent=None) -> None:
+    def __init__(
+        self, name: str, args: List["Node"], parent: Optional[BaseNode] = None
+    ) -> None:
         self.name = name
         self.args = args
         self.parent = parent
-        self.type = None
-        self.func_call_type = None
+        self.type: Union[str, List[str]] = ""
+        self.func_call_type: str = ""
         self.nodes = args
         self.immediate_args = ""
 
-    def process(self):
-        func = None
+    def process(self) -> None:
+
         if self.name in ("error", "push", "pop"):
             return self.process_special_call()
+
+        func: Optional[str] = None
         try:
             func = self.lookup_func(self.name)
         except KeyError:
             pass
-        if func:
-            return self.process_user_defined_func_call(func)
+
+        if func is not None:
+            return self.process_user_defined_func_call(func)  # type: ignore
+
+        op: Optional[Dict[str, Any]] = None
         try:
-            func = self.lookup_op(self.name)
+            op = self.lookup_op(self.name)
         except KeyError:
             pass
-        if func:
-            return self.process_op_call(func)
+
+        if op is not None:
+            return self.process_op_call(op)
         else:
             raise CompileError(f'Unknown function or opcode "{self.name}"', node=self)
 
-    def process_user_defined_func_call(self, func):
+    def process_user_defined_func_call(self, func: "FunctionCall") -> None:
         self.func_call_type = "user_defined"
         self.func = func
-        self.type = func.returns[0] if len(func.returns) == 1 else func.returns
+        self.type: List[str] = func.returns[0] if len(func.returns) == 1 else func.returns  # type: ignore
         for arg in self.args:
             arg.process()
 
-    def write_teal_user_defined_func_call(self, writer):
+    def write_teal_user_defined_func_call(self, writer: "TealWriter") -> None:
         for arg in self.args:
             writer.write(self, arg)
-        writer.write(self, f"callsub {self.func.label}")
+        writer.write(self, f"callsub {self.func.label}")  # type: ignore
 
-    def process_op_call(self, op):
+    def process_op_call(self, op: Dict[str, Any]) -> None:
         self.func_call_type = "op"
         self.op = op
         immediates = self.args[: (op["Size"] - 1)]
@@ -200,9 +219,9 @@ class FunctionCall(BaseNode):
             arg.process()
         self.check_arg_types(self.name, self.args)
         for i, x in enumerate(immediates):
-            if x.__class__.__name__ == "Constant":
+            if isinstance(x, Constant):
                 immediates[i] = x.name
-            elif x.__class__.__name__ == "Integer":
+            elif isinstance(x, Integer):
                 immediates[i] = x.value
         self.immediate_args = " ".join(map(str, immediates))
         returns = [
@@ -210,13 +229,13 @@ class FunctionCall(BaseNode):
         ][::-1]
         self.type = returns[0] if len(returns) == 1 else returns
 
-    def process_special_call(self):
+    def process_special_call(self) -> None:
         self.func_call_type = "special"
         self.type = "any"
         for arg in self.args:
             arg.process()
 
-    def write_teal_op_call(self, writer):
+    def write_teal_op_call(self, writer: "TealWriter") -> None:
         for arg in self.args:
             writer.write(self, arg)
         if self.immediate_args:
@@ -224,7 +243,7 @@ class FunctionCall(BaseNode):
         else:
             writer.write(self, f"{self.name}")
 
-    def write_teal_special_call(self, writer):
+    def write_teal_special_call(self, writer: "TealWriter") -> None:
         if self.name == "error":
             writer.write(self, "err")
         elif self.name == "push":
@@ -234,7 +253,7 @@ class FunctionCall(BaseNode):
         elif self.name == "pop":
             writer.write(self, "// pop")
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         if self.func_call_type == "user_defined":
             self.write_teal_user_defined_func_call(writer)
         elif self.func_call_type == "op":
@@ -242,7 +261,7 @@ class FunctionCall(BaseNode):
         elif self.func_call_type == "special":
             self.write_teal_special_call(writer)
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         args = [a.tealish() for a in self.args]
         if self.immediate_args:
             args = self.immediate_args.split(", ") + args
@@ -250,83 +269,97 @@ class FunctionCall(BaseNode):
 
 
 class TxnField(BaseNode):
-    def __init__(self, field, parent=None) -> None:
+    def __init__(self, field: str, parent: Optional[BaseNode] = None) -> None:
         self.field = field
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("txn", self.field)
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"txn {self.field}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Txn.{self.field}"
 
 
 class TxnArrayField(BaseNode):
-    def __init__(self, field, arrayIndex, parent=None) -> None:
+    def __init__(
+        self,
+        field: str,
+        arrayIndex: Union[Constant, Integer],
+        parent: Optional[BaseNode] = None,
+    ) -> None:
         self.field = field
         self.arrayIndex = arrayIndex
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("txn", self.field)
-        if type(self.arrayIndex) != Integer:
+        if isinstance(self.arrayIndex, Integer):
             # index is an expression that needs to be evaluated
             self.arrayIndex.process()
 
-    def write_teal(self, writer):
-        if type(self.arrayIndex) != Integer:
+    def write_teal(self, writer: "TealWriter") -> None:
+        if not isinstance(self.arrayIndex, Integer):
             writer.write(self, self.arrayIndex)
             writer.write(self, f"txnas {self.field}")
         else:
             # index is a constant
             writer.write(self, f"txna {self.field} {self.arrayIndex.value}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Txn.{self.field}[{self.arrayIndex.tealish()}]"
 
 
 class GroupTxnField(BaseNode):
-    def __init__(self, field, index, parent=None) -> None:
+    def __init__(
+        self, field: str, index: "Node", parent: Optional[BaseNode] = None
+    ) -> None:
         self.field = field
         self.index = index
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("gtxn", self.field)
         if type(self.index) != Integer:
             # index is an expression that needs to be evaluated
             self.index.process()
 
-    def write_teal(self, writer):
-        if type(self.index) != Integer:
-            # index is an expression that needs to be evaluated
-            writer.write(self, self.index)
-            writer.write(self, f"gtxns {self.field}")
-        else:
-            # index is a constant
+    def write_teal(self, writer: "TealWriter") -> None:
+        if isinstance(self.index, Integer):
             assert self.index.value >= 0, "Group index < 0"
             assert self.index.value < 16, "Group index > 16"
             writer.write(self, f"gtxn {self.index.value} {self.field}")
+        else:
+            # index is a constant
+            # TODO:
+            # index is an expression that needs to be evaluated
+            writer.write(self, self.index)
+            writer.write(self, f"gtxns {self.field}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Gtxn[{self.index.tealish()}].{self.field}"
 
 
 class GroupTxnArrayField(BaseNode):
-    def __init__(self, field, index, arrayIndex, parent=None) -> None:
+    def __init__(
+        self,
+        field: str,
+        index: "GenericExpression",
+        arrayIndex: Union[Constant, Integer],
+        parent: Optional[BaseNode] = None,
+    ) -> None:
         self.field = field
         self.index = index
         self.arrayIndex = arrayIndex
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("gtxn", self.field)
         if type(self.index) != Integer:
             # index is an expression that needs to be evaluated
@@ -334,8 +367,8 @@ class GroupTxnArrayField(BaseNode):
         if type(self.arrayIndex) != Integer:
             self.arrayIndex.process()
 
-    def write_teal(self, writer):
-        if type(self.index) != Integer:
+    def write_teal(self, writer: "TealWriter") -> None:
+        if not isinstance(self.index, Integer):
             # index is an expression that needs to be evaluated
             writer.write(self, self.index)
             if type(self.arrayIndex) != Integer:
@@ -359,80 +392,82 @@ class GroupTxnArrayField(BaseNode):
                     f"gtxna {self.index.value} {self.field} {self.arrayIndex.value}",
                 )
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Gtxn[{self.index.tealish()}].{self.field}[{self.arrayIndex.tealish()}]"
 
 
 class PositiveGroupIndex(BaseNode):
-    def __init__(self, index, parent=None) -> None:
+    def __init__(self, index: int, parent: Optional["BaseNode"] = None) -> None:
         self.index = index
         self.type = "int"
         self.parent = parent
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, "txn GroupIndex")
         writer.write(self, f"pushint {self.index}")
         writer.write(self, "+")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"+{self.index}"
 
 
 class NegativeGroupIndex(BaseNode):
-    def __init__(self, index, parent=None) -> None:
+    def __init__(self, index: int, parent: Optional[BaseNode] = None) -> None:
         self.index = index
         self.type = "int"
         self.parent = parent
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, "txn GroupIndex")
         writer.write(self, f"pushint {self.index}")
         writer.write(self, "-")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"-{self.index}"
 
 
 class GlobalField(BaseNode):
-    def __init__(self, field, parent=None) -> None:
+    def __init__(self, field: str, parent: Optional[BaseNode] = None) -> None:
         self.field = field
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("global", self.field)
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"global {self.field}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Global.{self.field}"
 
 
 class InnerTxnField(BaseNode):
-    def __init__(self, field, parent=None) -> None:
+    def __init__(self, field: str, parent: Optional[BaseNode] = None) -> None:
         self.field = field
         self.type = "any"
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.type = self.get_field_type("txn", self.field)
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"itxn {self.field}")
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"Itxn.{self.field}"
 
 
 class StructField(BaseNode):
-    def __init__(self, name, field, parent=None) -> None:
+    def __init__(
+        self, name: str, field: str, parent: Optional[BaseNode] = None
+    ) -> None:
         self.name = name
         self.field = field
-        self.type = "any"
+        self.type: List[str] = []
         self.parent = parent
 
-    def process(self):
+    def process(self) -> None:
         self.slot, self.type = self.lookup_var(self.name)
         self.object_type, struct_name = self.type
         struct = self.get_struct(struct_name)
@@ -442,7 +477,7 @@ class StructField(BaseNode):
         self.data_type = struct_field["type"]
         self.type = self.data_type
 
-    def write_teal(self, writer):
+    def write_teal(self, writer: "TealWriter") -> None:
         if self.object_type == "struct":
             writer.write(self, f"load {self.slot} // {self.name}")
             if self.type == "int":
@@ -453,11 +488,11 @@ class StructField(BaseNode):
         else:
             raise Exception()
 
-    def _tealish(self):
+    def _tealish(self) -> str:
         return f"{self.name}.{self.field}"
 
 
-def class_provider(name: str):
+def class_provider(name: str) -> Optional[type[BaseNode]]:
     classes = {
         "Variable": Variable,
         "Constant": Constant,

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -11,7 +11,7 @@ class Integer(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f"pushint {self.value}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"pushint {self.value}"
 
 
@@ -24,7 +24,7 @@ class Bytes(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f'pushbytes "{self.value}"')
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f'"{self.value}"'
 
 
@@ -46,7 +46,7 @@ class Variable(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f"load {self.slot} // {self.name}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"{self.name}"
 
 
@@ -80,7 +80,7 @@ class Constant(BaseNode):
         elif self.type == "bytes":
             writer.write(self, f"pushbytes {self.value} // {self.name}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"{self.name}"
 
 
@@ -101,7 +101,7 @@ class UnaryOp(BaseNode):
         writer.write(self, self.a)
         writer.write(self, f"{self.op}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"{self.op}{self.a.tealish(formatter)}"
 
 
@@ -125,7 +125,7 @@ class BinaryOp(BaseNode):
         writer.write(self, self.b)
         writer.write(self, f"{self.op}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"{self.a.tealish(formatter)} {self.op} {self.b.tealish(formatter)}"
 
 
@@ -142,7 +142,7 @@ class Group(BaseNode):
     def write_teal(self, writer):
         writer.write(self, self.expression)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"({self.expression.tealish(formatter)})"
 
 
@@ -242,7 +242,7 @@ class FunctionCall(BaseNode):
         elif self.func_call_type == "special":
             self.write_teal_special_call(writer)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         args = [a.tealish(formatter) for a in self.args]
         if self.immediate_args:
             args = self.immediate_args.split(", ") + args
@@ -261,7 +261,7 @@ class TxnField(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f"txn {self.field}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Txn.{self.field}"
 
 
@@ -286,7 +286,7 @@ class TxnArrayField(BaseNode):
             # index is a constant
             writer.write(self, f"txna {self.field} {self.arrayIndex.value}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Txn.{self.field}[{self.arrayIndex.tealish(formatter)}]"
 
 
@@ -314,7 +314,7 @@ class GroupTxnField(BaseNode):
             assert self.index.value < 16, "Group index > 16"
             writer.write(self, f"gtxn {self.index.value} {self.field}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Gtxn[{self.index.tealish(formatter)}].{self.field}"
 
 
@@ -359,7 +359,7 @@ class GroupTxnArrayField(BaseNode):
                     f"gtxna {self.index.value} {self.field} {self.arrayIndex.value}",
                 )
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Gtxn[{self.index.tealish(formatter)}].{self.field}[{self.arrayIndex.tealish(formatter)}]"
 
 
@@ -374,7 +374,7 @@ class PositiveGroupIndex(BaseNode):
         writer.write(self, f"pushint {self.index}")
         writer.write(self, "+")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"+{self.index}"
 
 
@@ -389,7 +389,7 @@ class NegativeGroupIndex(BaseNode):
         writer.write(self, f"pushint {self.index}")
         writer.write(self, "-")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"-{self.index}"
 
 
@@ -405,7 +405,7 @@ class GlobalField(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f"global {self.field}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Global.{self.field}"
 
 
@@ -421,7 +421,7 @@ class InnerTxnField(BaseNode):
     def write_teal(self, writer):
         writer.write(self, f"itxn {self.field}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"Itxn.{self.field}"
 
 
@@ -453,7 +453,7 @@ class StructField(BaseNode):
         else:
             raise Exception()
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return f"{self.name}.{self.field}"
 
 

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -102,7 +102,7 @@ class UnaryOp(BaseNode):
         writer.write(self, f"{self.op}")
 
     def _tealish(self):
-        return f"{self.op}{self.a.tealish(formatter)}"
+        return f"{self.op}{self.a.tealish()}"
 
 
 class BinaryOp(BaseNode):
@@ -126,7 +126,7 @@ class BinaryOp(BaseNode):
         writer.write(self, f"{self.op}")
 
     def _tealish(self):
-        return f"{self.a.tealish(formatter)} {self.op} {self.b.tealish(formatter)}"
+        return f"{self.a.tealish()} {self.op} {self.b.tealish()}"
 
 
 class Group(BaseNode):
@@ -143,7 +143,7 @@ class Group(BaseNode):
         writer.write(self, self.expression)
 
     def _tealish(self):
-        return f"({self.expression.tealish(formatter)})"
+        return f"({self.expression.tealish()})"
 
 
 class FunctionCall(BaseNode):
@@ -243,7 +243,7 @@ class FunctionCall(BaseNode):
             self.write_teal_special_call(writer)
 
     def _tealish(self):
-        args = [a.tealish(formatter) for a in self.args]
+        args = [a.tealish() for a in self.args]
         if self.immediate_args:
             args = self.immediate_args.split(", ") + args
         return f"{self.name}({', '.join(args)})"
@@ -287,7 +287,7 @@ class TxnArrayField(BaseNode):
             writer.write(self, f"txna {self.field} {self.arrayIndex.value}")
 
     def _tealish(self):
-        return f"Txn.{self.field}[{self.arrayIndex.tealish(formatter)}]"
+        return f"Txn.{self.field}[{self.arrayIndex.tealish()}]"
 
 
 class GroupTxnField(BaseNode):
@@ -315,7 +315,7 @@ class GroupTxnField(BaseNode):
             writer.write(self, f"gtxn {self.index.value} {self.field}")
 
     def _tealish(self):
-        return f"Gtxn[{self.index.tealish(formatter)}].{self.field}"
+        return f"Gtxn[{self.index.tealish()}].{self.field}"
 
 
 class GroupTxnArrayField(BaseNode):
@@ -360,7 +360,7 @@ class GroupTxnArrayField(BaseNode):
                 )
 
     def _tealish(self):
-        return f"Gtxn[{self.index.tealish(formatter)}].{self.field}[{self.arrayIndex.tealish(formatter)}]"
+        return f"Gtxn[{self.index.tealish()}].{self.field}[{self.arrayIndex.tealish()}]"
 
 
 class PositiveGroupIndex(BaseNode):

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -492,7 +492,7 @@ class StructField(BaseNode):
         return f"{self.name}.{self.field}"
 
 
-def class_provider(name: str) -> Optional[type[BaseNode]]:
+def class_provider(name: str) -> Optional[type]:
     classes = {
         "Variable": Variable,
         "Constant": Constant,

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -18,7 +18,7 @@ def type_lookup(a: str) -> str:
 
 
 class LangSpec:
-    def __init__(self, spec: dict[str, Any]) -> None:
+    def __init__(self, spec: Dict[str, Any]) -> None:
         self.is_packaged = False
         self.spec = spec
         self.fields: Dict[str, Any] = {
@@ -70,7 +70,7 @@ packaged_lang_spec = LangSpec(
 )
 packaged_lang_spec.is_packaged = True
 
-local_lang_spec: LangSpec
+local_lang_spec: Optional[LangSpec] = None
 if os.path.exists("langspec.json"):
     local_lang_spec = LangSpec(json.load(open("langspec.json")))
 

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Any, Tuple, Optional
 abc = "ABCDEFGHIJK"
 
 
-def type_lookup(a):
+def type_lookup(a: str) -> str:
     return {
         ".": "any",
         "B": "bytes",
@@ -18,7 +18,7 @@ def type_lookup(a):
 
 
 class LangSpec:
-    def __init__(self, spec) -> None:
+    def __init__(self, spec: dict[str, Any]) -> None:
         self.is_packaged = False
         self.spec = spec
         self.fields: Dict[str, Any] = {
@@ -55,10 +55,10 @@ class LangSpec:
                 sig += f"-> {ret}"
             op["sig"] = sig
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         return self.spec
 
-    def new_ops(self, old_spec):
+    def new_ops(self, old_spec: "LangSpec") -> List[Any]:
         _, new_ops = compare_langspecs(old_spec, self)
         return new_ops
 
@@ -79,10 +79,10 @@ def get_active_langspec() -> LangSpec:
     return packaged_lang_spec
 
 
-def get_new_local_ops(langspec: Optional[LangSpec] = None):
+def get_new_local_ops(langspec: Optional[LangSpec] = None) -> List[Any]:
     langspec = langspec or local_lang_spec
     if langspec is None:
-        return None
+        return []
     _, new_ops = compare_langspecs(packaged_lang_spec, langspec)
     return new_ops
 

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -70,7 +70,7 @@ packaged_lang_spec = LangSpec(
 )
 packaged_lang_spec.is_packaged = True
 
-local_lang_spec = None
+local_lang_spec: LangSpec
 if os.path.exists("langspec.json"):
     local_lang_spec = LangSpec(json.load(open("langspec.json")))
 

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -3,11 +3,9 @@ import os
 import requests
 import tealish
 import json
-from typing import Dict, Any
+from typing import List, Dict, Any, Tuple, Optional
 
 abc = "ABCDEFGHIJK"
-local_lang_spec = None
-packaged_lang_spec = None
 
 
 def type_lookup(a):
@@ -17,43 +15,6 @@ def type_lookup(a):
         "U": "int",
         "": "None",
     }[a]
-
-
-def get_active_langspec():
-    return local_lang_spec or packaged_lang_spec
-
-
-def get_new_local_ops(langspec=None):
-    langspec = langspec or local_lang_spec
-    if langspec is None:
-        return None
-    _, new_ops = compare_langspecs(packaged_lang_spec, langspec)
-    return new_ops
-
-
-def compare_langspecs(a, b):
-    a_new = []
-    b_new = []
-    for op in a.ops:
-        if op not in b.ops:
-            a_new.append(op)
-    for op in b.ops:
-        if op not in a.ops:
-            b_new.append(op)
-    return a_new, b_new
-
-
-def fetch_langspec(url):
-    if "http" not in url:
-        # assume branch name for go-algorand
-        branch = url
-        url = f"https://github.com/algorand/go-algorand/raw/{branch}/data/transactions/logic/langspec.json"
-    if "github.com" in url and "blob" in url:
-        url = url.replace("blob", "raw")
-    r = requests.get(url)
-    r.raise_for_status()
-    langspec_dict = r.json()
-    return LangSpec(langspec_dict)
 
 
 class LangSpec:
@@ -106,5 +67,46 @@ packaged_lang_spec = LangSpec(
     json.loads(importlib.resources.read_text(package=tealish, resource="langspec.json"))
 )
 packaged_lang_spec.is_packaged = True
+
+local_lang_spec = None
 if os.path.exists("langspec.json"):
     local_lang_spec = LangSpec(json.load(open("langspec.json")))
+
+
+def get_active_langspec() -> LangSpec:
+    if local_lang_spec is not None:
+        return local_lang_spec
+    return packaged_lang_spec
+
+
+def get_new_local_ops(langspec: Optional[LangSpec] = None):
+    langspec = langspec or local_lang_spec
+    if langspec is None:
+        return None
+    _, new_ops = compare_langspecs(packaged_lang_spec, langspec)
+    return new_ops
+
+
+def compare_langspecs(a: LangSpec, b: LangSpec) -> Tuple[List[Any], List[Any]]:
+    a_new = []
+    b_new = []
+    for op in a.ops:
+        if op not in b.ops:
+            a_new.append(op)
+    for op in b.ops:
+        if op not in a.ops:
+            b_new.append(op)
+    return a_new, b_new
+
+
+def fetch_langspec(url: str) -> LangSpec:
+    if "http" not in url:
+        # assume branch name for go-algorand
+        branch = url
+        url = f"https://github.com/algorand/go-algorand/raw/{branch}/data/transactions/logic/langspec.json"
+    if "github.com" in url and "blob" in url:
+        url = url.replace("blob", "raw")
+    r = requests.get(url)
+    r.raise_for_status()
+    langspec_dict = r.json()
+    return LangSpec(langspec_dict)

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -3,6 +3,7 @@ import os
 import requests
 import tealish
 import json
+from typing import Dict, Any
 
 abc = "ABCDEFGHIJK"
 local_lang_spec = None
@@ -59,7 +60,7 @@ class LangSpec:
     def __init__(self, spec) -> None:
         self.is_packaged = False
         self.spec = spec
-        self.fields = {
+        self.fields: Dict[str, Any] = {
             "Global": {},
             "Txn": {},
         }

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -27,7 +27,9 @@ class LangSpec:
         }
         self.global_fields = self.fields["Global"]
         self.txn_fields = self.fields["Txn"]
-        self.ops = {op["Name"]: dict(op) for op in spec["Ops"]}
+        self.ops: Dict[str, Dict[str, Any]] = {
+            op["Name"]: dict(op) for op in spec["Ops"]
+        }
         for i, field in enumerate(self.ops["global"]["ArgEnum"]):
             self.fields["Global"][field] = type_lookup(
                 self.ops["global"]["ArgEnumTypes"][i]

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -447,6 +447,7 @@ class Assert(LineStatement):
                 f"Incorrect type for assert. Expected int, got {self.arg.type} at line {self.line_no}.",
                 node=self,
             )
+
         # TODO: added check for compiler not None, should it ever happen that it is None?
         if self.message and self.compiler is not None:
             self.compiler.error_messages[self.line_no] = self.message

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -140,13 +140,13 @@ class LiteralInt(Expression):
     pattern = rf"(?P<value>{LITERAL_INT})$"
     value: int
 
-    def write_teal(self, writer: "TealWriter"):
+    def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushint {self.value}")
 
     def type(self) -> str:
         return "int"
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"{self.value}"
 
 
@@ -160,7 +160,7 @@ class LiteralBytes(Expression):
     def type(self) -> str:
         return "bytes"
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"{self.value}"
 
 
@@ -173,7 +173,7 @@ class Name(Expression):
         self._type: Optional[str] = None
         super().__init__(line)
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"{self.value}"
 
     def type(self) -> Optional[str]:
@@ -268,10 +268,10 @@ class Program(Node):
         for n in self.child_nodes:
             n.write_teal(writer)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         s = ""
         for n in self.child_nodes:
-            s += n.tealish(formatter)
+            s += n.tealish()
         return s
 
 
@@ -333,7 +333,7 @@ class TealVersion(LineStatement):
     def write_teal(self, writer: "TealWriter"):
         writer.write(self, f"#pragma version {self.version}")
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"#pragma version {self.version}\n"
 
 
@@ -344,7 +344,7 @@ class Comment(LineStatement):
     def write_teal(self, writer: "TealWriter"):
         writer.write(self, f"//{self.comment}")
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"#{self.comment}\n"
 
 
@@ -352,7 +352,7 @@ class Blank(LineStatement):
     def write_teal(self, writer: "TealWriter"):
         writer.write(self, "")
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return "\n"
 
 
@@ -369,10 +369,10 @@ class Const(LineStatement):
     def write_teal(self, writer: "TealWriter"):
         pass
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         s = f"const {self.type} {self.name}"
         if self.expression:
-            s += f" = {self.expression.tealish(formatter)}"
+            s += f" = {self.expression.tealish()}"
         return s + "\n"
 
 
@@ -385,7 +385,7 @@ class Jump(LineStatement):
         b = self.get_block(self.block_name)
         writer.write(self, f"b {b.label}")
 
-    def _tealish(self, formatter=None) -> str:
+    def _tealish(self) -> str:
         return f"jump {self.block_name}\n"
 
 
@@ -403,8 +403,8 @@ class Exit(LineStatement):
         writer.write(self, self.expression)
         writer.write(self, "return")
 
-    def _tealish(self, formatter=None) -> str:
-        return f"exit({self.expression.tealish(formatter)})\n"
+    def _tealish(self) -> str:
+        return f"exit({self.expression.tealish()})\n"
 
 
 class FunctionCallStatement(LineStatement):
@@ -424,8 +424,8 @@ class FunctionCallStatement(LineStatement):
         writer.write(self, f"// {self.line}")
         writer.write(self, self.expression)
 
-    def _tealish(self, formatter=None) -> str:
-        return f"{self.expression.tealish(formatter)}\n"
+    def _tealish(self) -> str:
+        return f"{self.expression.tealish()}\n"
 
 
 class Assert(LineStatement):
@@ -451,9 +451,9 @@ class Assert(LineStatement):
         else:
             writer.write(self, "assert")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         m = f', "{self.message}"' if self.message else ""
-        return f"assert({self.arg.tealish(formatter)}{m})\n"
+        return f"assert({self.arg.tealish()}{m})\n"
 
 
 class BytesDeclaration(LineStatement):
@@ -477,10 +477,10 @@ class BytesDeclaration(LineStatement):
             writer.write(self, self.expression)
             writer.write(self, f"store {self.name.slot} // {self.name.value}")
 
-    def _tealish(self, formatter=None):
-        s = f"bytes {self.name.tealish(formatter)}"
+    def _tealish(self):
+        s = f"bytes {self.name.tealish()}"
         if self.expression:
-            s += f" = {self.expression.tealish(formatter)}"
+            s += f" = {self.expression.tealish()}"
         return s + "\n"
 
 
@@ -505,10 +505,10 @@ class IntDeclaration(LineStatement):
             writer.write(self, self.expression)
             writer.write(self, f"store {self.name.slot} // {self.name.value}")
 
-    def _tealish(self, formatter=None):
-        s = f"int {self.name.tealish(formatter)}"
+    def _tealish(self):
+        s = f"int {self.name.tealish()}"
         if self.expression:
-            s += f" = {self.expression.tealish(formatter)}"
+            s += f" = {self.expression.tealish()}"
         return s + "\n"
 
 
@@ -553,8 +553,8 @@ class Assignment(LineStatement):
             else:
                 writer.write(self, f"store {name.slot} // {name.value}")
 
-    def _tealish(self, formatter=None):
-        s = f"{', '.join(n.tealish(formatter) for n in self.names)} = {self.expression.tealish(formatter)}\n"
+    def _tealish(self):
+        s = f"{', '.join(n.tealish() for n in self.names)} = {self.expression.tealish()}\n"
         return s
 
 
@@ -593,10 +593,10 @@ class Block(Statement):
             n.write_teal(writer)
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = f"block {self.name}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -606,8 +606,8 @@ class SwitchOption(Node):
     expression: GenericExpression
     block_name: str
 
-    def _tealish(self, formatter=None):
-        output = f"{self.expression.tealish(formatter)}: {self.block_name}\n"
+    def _tealish(self):
+        output = f"{self.expression.tealish()}: {self.block_name}\n"
         return output
 
 
@@ -615,7 +615,7 @@ class SwitchElse(Node):
     pattern = r"else: (?P<block_name>.*)"
     block_name: str
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = f"else: {self.block_name}\n"
         return output
 
@@ -674,10 +674,10 @@ class Switch(InlineStatement):
         else:
             writer.write(self, "err // unexpected value")
 
-    def _tealish(self, formatter=None):
-        output = f"switch {self.expression.tealish(formatter)}:\n"
+    def _tealish(self):
+        output = f"switch {self.expression.tealish()}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -704,7 +704,7 @@ class Teal(InlineStatement):
         for n in self.child_nodes:
             n.write_teal(writer)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = "teal:\n"
         for n in self.child_nodes:
             output += indent(n.line) + "\n"
@@ -723,9 +723,9 @@ class InnerTxnFieldSetter(InlineStatement):
         writer.write(self, self.expression)
         writer.write(self, f"itxn_field {self.field_name}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         array_index = f"[{self.index}]" if self.index is not None else ""
-        output = f"{self.field_name}{array_index}: {self.expression.tealish(formatter)}"
+        output = f"{self.field_name}{array_index}: {self.expression.tealish()}"
         return output
 
 
@@ -791,10 +791,10 @@ class InnerTxn(InlineStatement):
             writer.write(self, "itxn_submit")
         writer.write(self, "// end inner_txn")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = "inner_txn:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter)) + "\n"
+            output += indent(n.tealish()) + "\n"
         output += "end\n"
         return output
 
@@ -830,10 +830,10 @@ class InnerGroup(InlineStatement):
         writer.level -= 1
         writer.write(self, "// end inner_group")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = "inner_group:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -871,10 +871,10 @@ class IfThen(Node):
             n.write_teal(writer)
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = ""
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         return output
 
 
@@ -917,10 +917,10 @@ class Elif(Node):
             n.write_teal(writer)
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
-        output = f"elif {'not ' if self.modifier else ''}{self.condition.tealish(formatter)}:\n"
+    def _tealish(self):
+        output = f"elif {'not ' if self.modifier else ''}{self.condition.tealish()}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         return output
 
 
@@ -955,10 +955,10 @@ class Else(Node):
             n.write_teal(writer)
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = "else:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         return output
 
 
@@ -1062,10 +1062,10 @@ class IfStatement(InlineStatement):
         writer.write(self, f"{self.end_label}: // end")
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
-        output = f"if {'not ' if self.modifier else ''}{self.condition.tealish(formatter)}:\n"
+    def _tealish(self):
+        output = f"if {'not ' if self.modifier else ''}{self.condition.tealish()}:\n"
         for n in self.child_nodes:
-            output += n.tealish(formatter)
+            output += n.tealish()
         output += "end\n"
         return output
 
@@ -1085,7 +1085,7 @@ class Break(LineStatement):
         writer.write(self, f"// {self.line}")
         writer.write(self, f"b {self.parent_loop.end_label}")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         return "break\n"
 
 
@@ -1132,10 +1132,10 @@ class WhileStatement(InlineStatement):
         writer.write(self, f"{self.end_label}: // end")
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
-        output = f"while {'not ' if self.modifier else ''}{self.condition.tealish(formatter)}:\n"
+    def _tealish(self):
+        output = f"while {'not ' if self.modifier else ''}{self.condition.tealish()}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -1191,10 +1191,10 @@ class ForStatement(InlineStatement):
         self.del_var(self.var)
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
-        output = f"for {self.var} in {self.start.tealish(formatter)}:{self.end.tealish(formatter)}:\n"
+    def _tealish(self):
+        output = f"for {self.var} in {self.start.tealish()}:{self.end.tealish()}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -1245,12 +1245,10 @@ class For_Statement(InlineStatement):
         writer.write(self, f"{self.end_label}: // end")
         writer.level -= 1
 
-    def _tealish(self, formatter=None):
-        output = (
-            f"for _ in {self.start.tealish(formatter)}:{self.end.tealish(formatter)}:\n"
-        )
+    def _tealish(self):
+        output = f"for _ in {self.start.tealish()}:{self.end.tealish()}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -1264,7 +1262,7 @@ class ArgsList(Expression):
         super().__init__(string)
         self.args = re.findall(self.arg_pattern, string)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = ", ".join([f"{a}: {t}" for (a, t) in self.args])
         return output
 
@@ -1315,11 +1313,11 @@ class Func(InlineStatement):
         for node in self.child_nodes:
             node.write_teal(writer)
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         returns = (" " + (", ".join(self.returns))) if self.returns else ""
-        output = f"func {self.name}({self.args.tealish(formatter)}){returns}:\n"
+        output = f"func {self.name}({self.args.tealish()}){returns}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter))
+            output += indent(n.tealish())
         output += "end\n"
         return output
 
@@ -1333,7 +1331,7 @@ class Func(InlineStatement):
 #         super().__init__(string)
 #         self.args = re.findall(self.arg_pattern, string)
 
-#     def _tealish(self, formatter=None):
+#     def _tealish(self):
 #         output = ", ".join([f"{a}: {t}" for (a, t) in self.args])
 #         return output
 
@@ -1368,10 +1366,12 @@ class Return(LineStatement):
                 writer.write(self, expression)
         writer.write(self, "retsub")
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = "return"
         if self.args_expressions:
-            output += f" {', '.join([e.tealish(formatter) for e in self.args_expressions[::-1]])}"
+            output += (
+                f" {', '.join([e.tealish() for e in self.args_expressions[::-1]])}"
+            )
         return output + "\n"
 
 
@@ -1387,7 +1387,7 @@ class StructFieldDefinition(InlineStatement):
     def write_teal(self, writer):
         pass
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = f"{self.field_name}: {self.data_type}"
         return output
 
@@ -1450,10 +1450,10 @@ class Struct(InlineStatement):
     def write_teal(self, writer):
         pass
 
-    def _tealish(self, formatter=None):
+    def _tealish(self):
         output = f"struct {self.name}:\n"
         for n in self.child_nodes:
-            output += indent(n.tealish(formatter)) + "\n"
+            output += indent(n.tealish()) + "\n"
         output += "end\n"
         return output
 
@@ -1480,10 +1480,10 @@ class StructDeclaration(LineStatement):
             writer.write(self, self.expression)
             writer.write(self, f"store {self.name.slot} // {self.name.value}")
 
-    def _tealish(self, formatter=None):
-        s = f"{self.struct_name} {self.name.tealish(formatter)}"
+    def _tealish(self):
+        s = f"{self.struct_name} {self.name.tealish()}"
         if self.expression:
-            s += f" = {self.expression.tealish(formatter)}"
+            s += f" = {self.expression.tealish()}"
         return s + "\n"
 
 
@@ -1525,10 +1525,10 @@ class StructAssignment(LineStatement):
             )
             writer.write(self, f"store {self.name.slot} // {self.name.value}")
 
-    def _tealish(self, formatter=None) -> str:
-        s = f"{self.name} {self.name.tealish(formatter)}"
+    def _tealish(self) -> str:
+        s = f"{self.name} {self.name.tealish()}"
         if self.expression:
-            s += f" = {self.expression.tealish(formatter)}"
+            s += f" = {self.expression.tealish()}"
         return s + "\n"
 
 

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -48,18 +48,14 @@ class Node(BaseNode):
         # self.nodes includes structural nodes and child_nodes (e.g. function args and body, if conditions and child statements)
         self.nodes: List[BaseNode] = []
         self.properties = {}
-        try:
-            matches: Optional[re.Match[str]] = re.match(self.pattern, self.line)
-            # TODO: this is weird structure, attribute error is for if pattern or line is not defined?
-            if matches is None:
-                raise ParseError(
-                    f'Pattern ({self.pattern}) does not match for {self} for line "{self.line}"'
-                )
-            self.matches = matches.groupdict()
-        except AttributeError:
+
+        matches: Optional[re.Match[str]] = re.match(self.pattern, self.line)
+        if matches is None:
             raise ParseError(
                 f'Pattern ({self.pattern}) does not match for {self} for line "{self.line}"'
             )
+        self.matches = matches.groupdict()
+
         type_hints = get_type_hints(self.__class__)
         for name, expr_class in type_hints.items():
             if name in self.matches:
@@ -1366,7 +1362,6 @@ class ArgsList(Expression):
     def __init__(self, line: str) -> None:
         super().__init__(line)
         self.args = re.findall(self.arg_pattern, line)
-        print(self.args)
 
     def _tealish(self) -> str:
         output = ", ".join([f"{a}: {t}" for (a, t) in self.args])

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -1,13 +1,15 @@
-constants = {
-    "NoOp": ["int", 0],
-    "OptIn": ["int", 1],
-    "CloseOut": ["int", 2],
-    "ClearState": ["int", 3],
-    "UpdateApplication": ["int", 4],
-    "DeleteApplication": ["int", 5],
-    "Pay": ["int", 1],
-    "Acfg": ["int", 3],
-    "Axfer": ["int", 4],
-    "Afrz": ["int", 5],
-    "Appl": ["int", 6],
+from typing import Dict, Tuple
+
+constants: Dict[str, Tuple[str, int]] = {
+    "NoOp": ("int", 0),
+    "OptIn": ("int", 1),
+    "CloseOut": ("int", 2),
+    "ClearState": ("int", 3),
+    "UpdateApplication": ("int", 4),
+    "DeleteApplication": ("int", 5),
+    "Pay": ("int", 1),
+    "Acfg": ("int", 3),
+    "Axfer": ("int", 4),
+    "Afrz": ("int", 5),
+    "Appl": ("int", 6),
 }

--- a/tealish/tx_expressions.py
+++ b/tealish/tx_expressions.py
@@ -1,6 +1,6 @@
 import importlib.resources
 import tealish
-from textx.metamodel import metamodel_from_file  # type: ignore
+from textx.metamodel import metamodel_from_file
 from .expression_nodes import class_provider
 
 from typing import TYPE_CHECKING

--- a/tealish/tx_expressions.py
+++ b/tealish/tx_expressions.py
@@ -19,6 +19,6 @@ with importlib.resources.path(tealish, "tealish_expressions.tx") as p:
     )
 
 
-def parse_expression(source) -> "Node":
+def parse_expression(source: str) -> "Node":
     node = tealish_mm.model_from_str(source)
     return node

--- a/tealish/tx_expressions.py
+++ b/tealish/tx_expressions.py
@@ -1,6 +1,6 @@
 import importlib.resources
 import tealish
-from textx.metamodel import metamodel_from_file
+from textx.metamodel import metamodel_from_file  # type: ignore
 from .expression_nodes import class_provider
 
 with importlib.resources.path(tealish, "tealish_expressions.tx") as p:

--- a/tealish/tx_expressions.py
+++ b/tealish/tx_expressions.py
@@ -3,6 +3,11 @@ import tealish
 from textx.metamodel import metamodel_from_file  # type: ignore
 from .expression_nodes import class_provider
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .nodes import Node
+
 with importlib.resources.path(tealish, "tealish_expressions.tx") as p:
     tealish_mm = metamodel_from_file(
         p,
@@ -14,6 +19,6 @@ with importlib.resources.path(tealish, "tealish_expressions.tx") as p:
     )
 
 
-def parse_expression(source):
+def parse_expression(source) -> "Node":
     node = tealish_mm.model_from_str(source)
     return node

--- a/tealish/utils.py
+++ b/tealish/utils.py
@@ -1,4 +1,5 @@
-from algosdk import source_map
+from typing import Dict, List
+from algosdk import source_map  # type: ignore
 
 
 def minify_teal(teal_lines):
@@ -51,7 +52,7 @@ class TealishMap:
             int(k): int(v) for k, v in map.get("teal_tealish", {}).items()
         }
         self.errors = {int(k): v for k, v in map.get("errors", {}).items()}
-        self.tealish_teal = {}
+        self.tealish_teal: Dict[int, List[int]] = {}
         for teal, tealish in self.teal_tealish.items():
             if tealish not in self.tealish_teal:
                 self.tealish_teal[tealish] = []

--- a/tealish/utils.py
+++ b/tealish/utils.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Tuple, Optional, Union, Any
-from algosdk import source_map  # type: ignore
+from algosdk.source_map import SourceMap
 
 
 def minify_teal(teal_lines: List[str]) -> Tuple[List[str], Dict[int, int]]:
@@ -80,10 +80,10 @@ class TealishMap:
         return None
 
     def update_from_teal_sourcemap(
-        self, sourcemap: Union[Dict[str, Any], source_map.SourceMap]
+        self, sourcemap: Union[Dict[str, Any], SourceMap]
     ) -> None:
-        sourcemap = source_map.SourceMap(sourcemap)
-        if isinstance(sourcemap, source_map.SourceMap):
+        sourcemap = SourceMap(sourcemap)
+        if isinstance(sourcemap, SourceMap):
             self.pc_teal = dict(sourcemap.pc_to_line)
 
     def as_dict(self) -> Dict[str, Any]:

--- a/tealish/utils.py
+++ b/tealish/utils.py
@@ -45,13 +45,15 @@ def strip_comments(teal_lines: List[str]) -> List[str]:
 
 
 class TealishMap:
-    def __init__(self, map: Optional[Dict[str, Dict[int, int]]] = None) -> None:
+    def __init__(self, map: Optional[Dict[str, Any]] = None) -> None:
         map = map or {}
         self.pc_teal = {int(k): int(v) for k, v in map.get("pc_teal", {}).items()}
         self.teal_tealish = {
             int(k): int(v) for k, v in map.get("teal_tealish", {}).items()
         }
-        self.errors = {int(k): v for k, v in map.get("errors", {}).items()}
+        self.errors: Dict[int, str] = {
+            int(k): v for k, v in map.get("errors", {}).items()
+        }
         self.tealish_teal: Dict[int, List[int]] = {}
         for teal, tealish in self.teal_tealish.items():
             if tealish not in self.tealish_teal:
@@ -73,7 +75,7 @@ class TealishMap:
     def get_tealish_line_for_teal(self, teal_line: int) -> Optional[int]:
         return self.teal_tealish.get(teal_line, None)
 
-    def get_error_for_pc(self, pc: int) -> Optional[int]:
+    def get_error_for_pc(self, pc: int) -> Optional[str]:
         tealish_line = self.get_tealish_line_for_pc(pc)
         if tealish_line is not None:
             return self.errors.get(tealish_line, None)

--- a/tests/test.py
+++ b/tests/test.py
@@ -257,7 +257,8 @@ class TestAssignment(unittest.TestCase):
         with self.assertRaises(CompileError) as e:
             _ = compile_min(["x = 1"])
         self.assertEqual(
-            e.exception.args[0], 'Var "x" not declared in current scope at line 1'
+            e.exception.args[0],
+            'Var "x" not declared in current scope at line 1\n x = 1',
         )
 
     def test_fail_invalid(self):


### PR DESCRIPTION
Overview
----------

This pr adds type hints that can be validated using `mypy` and also adds a `mypy.ini` config file that only has directives to ignore types in external packages.

1) Find functions in need of annotations with `mypy tealish --disallow-untyped-defs` and add them.
2) Run `pytest -x tests/*` to make sure nothing broke
3) repeat


Status
------

While it is ready for review, there are a number of places where I marked `TODO:` for follow ups and others I annotated with `#type: ignore` to prevent mypy from complaining.


Needs
-------

There are a few issues that need to be resolved:

1) Determining whether Node or BaseNode should be used in different cases. This presents as undefined attributes.
2) Better definitions of some Dict types, namely for `Op`, `Scope`, and `Struct`
3) Improved typing that should make me feel better about the current `str` type ('bytes'|'int'|'any'|'None')
4) Try to remove as many Optional types as possible so we don't have to do the None check



It may also be prudent to add a few more tests to validate I've not broken anything.

