### PR TITLE
Fix Python Package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ dependencies = [
 
 [project.scripts]
 tealish = "tealish.cli:cli"
+
+[tool.setuptools.package-data]
+tealish = ["langspec.json", "tealish_expressions.tx"]


### PR DESCRIPTION
- Added `langspec.json` and `tealish_expressions.tx` files to package.

##  `pip freeze`
```
algojig==0.0.1
Arpeggio==2.0.0
certifi==2022.12.7
cffi==1.15.1
charset-normalizer==3.0.1
click==8.1.3
future==0.18.3
idna==3.4
msgpack==1.0.4
py-algorand-sdk==1.20.0
pycparser==2.21
pycryptodomex==3.16.0
PyNaCl==1.5.0
requests==2.28.2
tealish @ git+https://github.com/tinymanorg/tealish.git@73b959340e38965174e2dc9e07b1f0ab6446351a
textX==3.0.0
urllib3==1.26.14
```

## Error
```
Traceback (most recent call last):
  File "/Users/gokselcoban/hipo/tinyman/tinyman-periphery-contracts-v2/.env/bin/tealish", line 5, in <module>
    from tealish.cli import cli
  File "/Users/gokselcoban/hipo/tinyman/tinyman-periphery-contracts-v2/.env/lib/python3.9/site-packages/tealish/__init__.py", line 1, in <module>
    from .nodes import Program
  File "/Users/gokselcoban/hipo/tinyman/tinyman-periphery-contracts-v2/.env/lib/python3.9/site-packages/tealish/nodes.py", line 5, in <module>
    from .base import BaseNode
  File "/Users/gokselcoban/hipo/tinyman/tinyman-periphery-contracts-v2/.env/lib/python3.9/site-packages/tealish/base.py", line 3, in <module>
    from .langspec import get_active_langspec
  File "/Users/gokselcoban/hipo/tinyman/tinyman-periphery-contracts-v2/.env/lib/python3.9/site-packages/tealish/langspec.py", line 105, in <module>
    json.loads(importlib.resources.read_text(package=tealish, resource="langspec.json"))
  File "/Users/gokselcoban/.pyenv/versions/3.9.5/lib/python3.9/importlib/resources.py", line 139, in read_text
    with open_text(package, resource, encoding, errors) as fp:
  File "/Users/gokselcoban/.pyenv/versions/3.9.5/lib/python3.9/importlib/resources.py", line 121, in open_text
    open_binary(package, resource), encoding=encoding, errors=errors)
  File "/Users/gokselcoban/.pyenv/versions/3.9.5/lib/python3.9/importlib/resources.py", line 91, in open_binary
    return reader.open_resource(resource)
  File "<frozen importlib._bootstrap_external>", line 1060, in open_resource
```