### PR TITLE
Consolidate types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 .DS_Store
 .idea
+.vscode/

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import cast, Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from tealish.errors import CompileError
 from .tealish_builtins import AVMType, ConstValue, ScratchRecord, VarType
 from .langspec import get_active_langspec, Op
@@ -142,7 +142,7 @@ class BaseNode:
         except Exception as e:
             raise CompileError(str(e), node=self)  # type: ignore
 
-    def get_field_type(self, namespace: str, name: str) -> str:
+    def get_field_type(self, namespace: str, name: str) -> AVMType:
         return lang_spec.get_field_type(namespace, name)
 
     def lookup_op(self, name: str) -> Op:

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,6 +1,6 @@
 from typing import cast, Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from tealish.errors import CompileError
-from .tealish_builtins import AVMType, VarType, ConstValue
+from .tealish_builtins import AVMType, ConstValue, ScratchRecord, VarType
 from .langspec import get_active_langspec, Op
 from .scope import Scope
 
@@ -72,14 +72,14 @@ class BaseNode:
             slots.update(s.slots)
         return slots
 
-    def get_var(self, name: str) -> Optional[Tuple[int, VarType]]:
+    def get_var(self, name: str) -> Optional[ScratchRecord]:
         slots = self.get_slots()
         if name in slots:
             return slots[name]
         else:
             return None
 
-    def declare_var(self, name: str, type: Union[AVMType, Tuple[str, str]]) -> int:
+    def declare_var(self, name: str, type: VarType) -> int:
         scope = self.get_current_scope()
         # TODO: this fixed the issue of slot assignment in the `main`
         # but i'm not sure why...

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,8 +1,8 @@
 from typing import cast, Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from tealish.errors import CompileError
-from .tealish_builtins import AVMType
+from .tealish_builtins import AVMType, VarType, ConstValue
 from .langspec import get_active_langspec, Op
-from .scope import Scope, VarType, ConstValue
+from .scope import Scope
 
 
 if TYPE_CHECKING:

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -126,8 +126,8 @@ class LangSpec:
             "Txn": self.ops["txn"].arg_enum_dict,
         }
 
-        self.global_fields = self.fields["Global"]
-        self.txn_fields = self.fields["Txn"]
+        self.global_fields: Dict[str, AVMType] = self.fields["Global"]
+        self.txn_fields: Dict[str, AVMType] = self.fields["Txn"]
 
     def as_dict(self) -> Dict[str, Any]:
         return self.spec
@@ -146,7 +146,7 @@ class LangSpec:
             raise KeyError(f'Constant "{name}" does not exist!')
         return constants[name]
 
-    def get_field_type(self, namespace: str, name: str) -> str:
+    def get_field_type(self, namespace: str, name: str) -> AVMType:
         if "txn" in namespace:
             return self.txn_fields[name]
         elif namespace == "global":
@@ -195,7 +195,10 @@ def fetch_langspec(url: str) -> LangSpec:
     if "http" not in url:
         # assume branch name for go-algorand
         branch = url
-        url = f"https://github.com/algorand/go-algorand/raw/{branch}/data/transactions/logic/langspec.json"
+        url = (
+            f"https://github.com/algorand/go-algorand/raw/{branch}"
+            "/data/transactions/logic/langspec.json"
+        )
     if "github.com" in url and "blob" in url:
         url = url.replace("blob", "raw")
     r = requests.get(url)

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -14,12 +14,7 @@ from typing import (
 from .base import BaseNode
 from .errors import CompileError, ParseError
 from .tx_expressions import parse_expression
-from .tealish_builtins import (
-    AVMType,
-    define_struct,
-    get_struct,
-    VarType
-)
+from .tealish_builtins import AVMType, TealishType, define_struct, get_struct, VarType
 from .scope import Scope
 
 LITERAL_INT = r"[0-9]+"
@@ -1606,7 +1601,9 @@ class StructDeclaration(LineStatement):
     expression: GenericExpression
 
     def process(self) -> None:
-        self.name.slot = self.declare_var(self.name.value, ("struct", self.struct_name))
+        self.name.slot = self.declare_var(
+            self.name.value, (TealishType.struct, self.struct_name)
+        )
         if self.expression:
             self.expression.process()
             if self.expression.type not in (AVMType.bytes, AVMType.any):
@@ -1700,7 +1697,9 @@ class BoxDeclaration(LineStatement):
     def process(self):
         self.struct = get_struct(self.struct_name)
         self.box_size = self.struct.size
-        self.name.slot = self.declare_var(self.name.value, ("box", self.struct_name))
+        self.name.slot = self.declare_var(
+            self.name.value, (TealishType.box, self.struct_name)
+        )
         self.key.process()
         if self.key.type not in ("bytes", "any"):
             raise CompileError(

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -1701,7 +1701,7 @@ class BoxDeclaration(LineStatement):
             self.name.value, (TealishType.box, self.struct_name)
         )
         self.key.process()
-        if self.key.type not in ("bytes", "any"):
+        if self.key.type not in (AVMType.bytes, AVMType.any):
             raise CompileError(
                 f"Incorrect type for box key. Expected bytes, got {self.key.type}",
                 node=self,

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -18,8 +18,9 @@ from .tealish_builtins import (
     AVMType,
     define_struct,
     get_struct,
+    VarType
 )
-from .scope import Scope, VarType
+from .scope import Scope
 
 LITERAL_INT = r"[0-9]+"
 LITERAL_BYTES = r'"(.+)"'

--- a/tealish/scope.py
+++ b/tealish/scope.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 
 if TYPE_CHECKING:

--- a/tealish/scope.py
+++ b/tealish/scope.py
@@ -2,10 +2,8 @@ from typing import Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from .tealish_builtins import AVMType, VarType, ConstValue
+    from .tealish_builtins import AVMType, VarType, ConstValue, ScratchRecord
     from .nodes import Func, Block
-
-
 
 
 class Scope:
@@ -18,7 +16,7 @@ class Scope:
         self.name = name
         self.parent = parent_scope
 
-        self.slots: Dict[str, Tuple[int, "VarType"]] = {}
+        self.slots: Dict[str, "ScratchRecord"] = {}
         self.slot_range: Tuple[int, int] = (
             slot_range if slot_range is not None else (0, 200)
         )
@@ -51,7 +49,7 @@ class Scope:
         self.slots[name] = (slot, type_info)
         return slot
 
-    def lookup_var(self, name: str) -> Tuple[int, "VarType"]:
+    def lookup_var(self, name: str) -> "ScratchRecord":
         if name not in self.slots:
             raise KeyError(f'Var "{name}" not declared in current scope')
         return self.slots[name]

--- a/tealish/scope.py
+++ b/tealish/scope.py
@@ -2,12 +2,10 @@ from typing import Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from .tealish_builtins import AVMType
+    from .tealish_builtins import AVMType, VarType, ConstValue
     from .nodes import Func, Block
 
 
-VarType = Union["AVMType", Tuple[str, str]]
-ConstValue = Union[str, bytes, int]
 
 
 class Scope:
@@ -20,12 +18,12 @@ class Scope:
         self.name = name
         self.parent = parent_scope
 
-        self.slots: Dict[str, Tuple[int, VarType]] = {}
+        self.slots: Dict[str, Tuple[int, "VarType"]] = {}
         self.slot_range: Tuple[int, int] = (
             slot_range if slot_range is not None else (0, 200)
         )
 
-        self.consts: Dict[str, Tuple["AVMType", ConstValue]] = {}
+        self.consts: Dict[str, Tuple["AVMType", "ConstValue"]] = {}
         self.blocks: Dict[str, "Block"] = {}
         self.functions: Dict[str, "Func"] = {}
 
@@ -43,7 +41,7 @@ class Scope:
     def declare_var(
         self,
         name: str,
-        type_info: VarType,
+        type_info: "VarType",
         max_slot: Optional[int] = None,
     ) -> int:
         if name in self.slots:
@@ -53,7 +51,7 @@ class Scope:
         self.slots[name] = (slot, type_info)
         return slot
 
-    def lookup_var(self, name: str) -> Tuple[int, VarType]:
+    def lookup_var(self, name: str) -> Tuple[int, "VarType"]:
         if name not in self.slots:
             raise KeyError(f'Var "{name}" not declared in current scope')
         return self.slots[name]
@@ -63,11 +61,11 @@ class Scope:
             del self.slots[name]
 
     def declare_const(
-        self, name: str, const_data: Tuple["AVMType", ConstValue]
+        self, name: str, const_data: Tuple["AVMType", "ConstValue"]
     ) -> None:
         self.consts[name] = const_data
 
-    def lookup_const(self, name: str) -> Tuple["AVMType", ConstValue]:
+    def lookup_const(self, name: str) -> Tuple["AVMType", "ConstValue"]:
         if name not in self.consts:
             raise KeyError(f'Const "{name}" not declared in current scope')
         return self.consts[name]

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -14,8 +14,24 @@ class AVMType(str, Enum):
     int = "int"
     none = ""
 
-VarType = Union[AVMType, Tuple[str, str]]
+
+class TealishType(str, Enum):
+    struct = "struct"
+    box = "box"
+
+
+# refers to a the custom type name, ie struct_name or box_name
+StructName = str
+CustomType = Tuple[TealishType, StructName]
+
+# either AVM native type or summn special
+VarType = Union[AVMType, CustomType]
+
+# a constant value introduced in source
 ConstValue = Union[str, bytes, int]
+
+# The data structure representing a value stored in a scratch slot
+ScratchRecord = Tuple[int, VarType]
 
 structs: Dict[str, "Struct"] = {}
 

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Dict, Tuple, Union, TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from .nodes import Struct
 
@@ -13,6 +14,8 @@ class AVMType(str, Enum):
     int = "int"
     none = ""
 
+VarType = Union[AVMType, Tuple[str, str]]
+ConstValue = Union[str, bytes, int]
 
 structs: Dict[str, "Struct"] = {}
 

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -15,16 +15,27 @@ class AVMType(str, Enum):
     none = ""
 
 
-class TealishType(str, Enum):
+class ObjectType(str, Enum):
+    """ObjectType determines where to get the bytes for a struct field.
+
+    `struct` - the field is in a byte array in a scratch var, use extract to get bytes
+    `box` - the field is in a box, use box_extract to get the bytes
+    """
+
     struct = "struct"
     box = "box"
 
 
-# refers to a the custom type name, ie struct_name or box_name
-StructName = str
-CustomType = Tuple[TealishType, StructName]
+# TODO: for CustomType and ScratchRecord we should consider
+# making them dataclasses or something instead of a tuple
+# to make it more obvious what the fields are
 
-# either AVM native type or summn special
+# refers to a the custom type name, ie struct_name or box_name
+# so we can look it up
+StructName = str
+CustomType = Tuple[ObjectType, StructName]
+
+# either AVM native type or a CustomType definition
 VarType = Union[AVMType, CustomType]
 
 # a constant value introduced in source
@@ -33,18 +44,19 @@ ConstValue = Union[str, bytes, int]
 # The data structure representing a value stored in a scratch slot
 ScratchRecord = Tuple[int, VarType]
 
-structs: Dict[str, "Struct"] = {}
+# Set of custom defined types
+_structs: Dict[StructName, "Struct"] = {}
 
 
 def define_struct(struct_name: str, struct: "Struct") -> None:
-    structs[struct_name] = struct
+    _structs[struct_name] = struct
 
 
 def get_struct(struct_name: str) -> "Struct":
-    return structs[struct_name]
+    return _structs[struct_name]
 
 
-constants: Dict[str, Tuple[AVMType, Union[str, bytes, int]]] = {
+constants: Dict[str, Tuple[AVMType, ConstValue]] = {
     "NoOp": (AVMType.int, 0),
     "OptIn": (AVMType.int, 1),
     "CloseOut": (AVMType.int, 2),

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -12,6 +12,8 @@ class AVMType(str, Enum):
     none = ""
 
 
+# TODO: add frame ptr or stack? rename to something like `storage type?`
+# I think `struct` here should probably just be `scratch`?
 class ObjectType(str, Enum):
     """ObjectType determines where to get the bytes for a struct field.
 
@@ -28,9 +30,8 @@ class ObjectType(str, Enum):
 # to make it more obvious what the fields are
 
 # refers to a the custom type name, ie struct_name or box_name
-# so we can look it up
-StructName = str
-CustomType = Tuple[ObjectType, StructName]
+# so we can look it up,
+CustomType = Tuple[ObjectType, str]
 
 
 @dataclass
@@ -42,12 +43,17 @@ class StructField:
 
 
 class Struct:
+    """
+    Holds definition of a struct type with a map of
+        `field name` =>  `struct field` details
+    """
+
     def __init__(self, fields: Dict[str, StructField], size: int):
         self.fields = fields
         self.size = size
 
 
-# either AVM native type or a CustomType definition
+# either AVM native type or a CustomType (only struct atm) definition
 VarType = Union[AVMType, CustomType]
 
 # a constant value introduced in source
@@ -57,7 +63,7 @@ ConstValue = Union[str, bytes, int]
 ScratchRecord = Tuple[int, VarType]
 
 # Set of custom defined types
-_structs: Dict[StructName, Struct] = {}
+_structs: Dict[str, Struct] = {}
 
 
 def define_struct(struct_name: str, struct: Struct) -> None:

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -1,9 +1,6 @@
 from enum import Enum
-from typing import Dict, Tuple, Union, TYPE_CHECKING
-
-
-if TYPE_CHECKING:
-    from .nodes import Struct
+from dataclasses import dataclass
+from typing import Dict, Tuple, Union
 
 
 class AVMType(str, Enum):
@@ -35,6 +32,21 @@ class ObjectType(str, Enum):
 StructName = str
 CustomType = Tuple[ObjectType, StructName]
 
+
+@dataclass
+class StructField:
+    data_type: AVMType
+    data_length: int
+    offset: int
+    size: int
+
+
+class Struct:
+    def __init__(self, fields: Dict[str, StructField], size: int):
+        self.fields = fields
+        self.size = size
+
+
 # either AVM native type or a CustomType definition
 VarType = Union[AVMType, CustomType]
 
@@ -45,14 +57,14 @@ ConstValue = Union[str, bytes, int]
 ScratchRecord = Tuple[int, VarType]
 
 # Set of custom defined types
-_structs: Dict[StructName, "Struct"] = {}
+_structs: Dict[StructName, Struct] = {}
 
 
-def define_struct(struct_name: str, struct: "Struct") -> None:
+def define_struct(struct_name: str, struct: Struct) -> None:
     _structs[struct_name] = struct
 
 
-def get_struct(struct_name: str) -> "Struct":
+def get_struct(struct_name: str) -> Struct:
     return _structs[struct_name]
 
 


### PR DESCRIPTION
1) Replaced some `str` to use `AVMType`, added new `ScratchRecord` type to replace the `Tuple` scattered around

2) New Enum type `ObjectType` to describe where some data is stored/how to access it.

      - I think this naming could use some thought, ObjectType should probably be called StorageBacking or something?
      - We should probably consider a couple more types for it like `frame_pointer` and `stack`?

3) New classes for `Struct`/`StructField` in `builtins` so metadata is not pulled from the AST Node itself but a wholly separate object
  
     - I _think_ this should help isolate concerns since the `Node` should probably not be used as the main object to access information about the user defined type
