### PR TITLE
Fix GroupTxnArrayField to use GroupIndex instead of Expression

### DIFF
--- a/tealish/tealish_expressions.tx
+++ b/tealish/tealish_expressions.tx
@@ -22,7 +22,7 @@ FieldName: /([A-Z][A-Za-z_]+)/;
 TxnField: 'Txn.' field=FieldName;
 TxnArrayField: 'Txn.' field=FieldName '[' arrayIndex=Expression ']';
 GroupTxnField: 'Gtxn[' index=GroupIndex '].' field=FieldName;
-GroupTxnArrayField: 'Gtxn[' index=Expression '].' field=FieldName '[' arrayIndex=Expression ']';
+GroupTxnArrayField: 'Gtxn[' index=GroupIndex '].' field=FieldName '[' arrayIndex=Expression ']';
 InnerTxnField: 'Itxn.' field=FieldName;
 InnerTxnArrayField: 'Itxn.' field=FieldName '[' arrayIndex=Expression ']';
 GlobalField: 'Global.' field=FieldName;

--- a/tests/test.py
+++ b/tests/test.py
@@ -121,6 +121,12 @@ class TestFields(unittest.TestCase):
             teal, ["txn GroupIndex", "pushint 1", "+", "gtxns TypeEnum"]
         )
 
+    def test_group_index_negative_array_field(self):
+        teal = compile_expression_min("Gtxn[-1].Accounts[0]")
+        self.assertListEqual(
+            teal, ["txn GroupIndex", "pushint 1", "-", "gtxnsa Accounts 0"]
+        )
+
     def test_group_index_var(self):
         scope = Scope()
         scope.declare_var("index", AVMType.int)


### PR DESCRIPTION
Fixes issue reported by wolven on Discord:

>For some reason, 
>`assert(Gtxn[-2].ApplicationArgs[0] == OPT_IN_ASSET)`
> produces
> `Cannot parse "Gtxn[-2].ApplicationArgs[0] == OPT_IN_ASSET" as Expression at line 86`
> but
> `assert(Gtxn[Txn.GroupIndex - 2].ApplicationArgs[0] == OPT_IN_ASSET)`
> compiles fine.

