### PR TITLE
Exit statement checks

### DIFF
--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -268,6 +268,7 @@ class Program(Node):
     def consume(cls, compiler: "TealishCompiler", parent: Optional[Node]) -> "Program":
         node = Program("", parent=parent, compiler=compiler)
         expect_struct_definition = True
+        exit_statement = None
         while True:
             if compiler.peek() is None:
                 break
@@ -280,6 +281,22 @@ class Program(Node):
                 )
             if not isinstance(n, (TealVersion, Blank, Comment, Struct)):
                 expect_struct_definition = False
+
+            if exit_statement:
+                if not isinstance(n, (Func, Block, Comment, Blank)):
+                    raise ParseError(
+                        f"Unexpected statement at line {n.line_no}."
+                        + f" Only Block and Function definitions should occure after a {exit_statement}."
+                    )
+            else:
+                if isinstance(n, (Func, Block)):
+                    raise ParseError(
+                        f"Unexpected {n} definition at line {n.line_no}. "
+                        + "Block and Function definitions must occur after an exit statement (e.g Exit, switch, jump)."
+                    )
+            if is_exit_statement(n):
+                exit_statement = n
+
             node.add_child(n)
         return node
 
@@ -623,11 +640,29 @@ class Block(Statement):
     def consume(cls, compiler: "TealishCompiler", parent: Optional[Node]) -> "Block":
         line = compiler.consume_line()
         block = Block(line, parent, compiler=compiler)
+        exit_statement = None
         while True:
             if compiler.peek() == "end":
                 compiler.consume_line()
                 break
-            block.add_child(Statement.consume(compiler, block))
+
+            n = Statement.consume(compiler, block)
+            if exit_statement:
+                if not isinstance(n, (Func, Block, Comment, Blank)):
+                    raise ParseError(
+                        f"Unexpected statement at line {n.line_no}."
+                        + f" Only Block and Function definitions should occure after a {exit_statement}."
+                    )
+            else:
+                if isinstance(n, (Func, Block)):
+                    raise ParseError(
+                        f"Unexpected {n} definition at line {n.line_no}. "
+                        + "Block and Function definitions must occur after an exit statement (e.g Exit, switch, jump)."
+                    )
+            if is_exit_statement(n):
+                exit_statement = n
+
+            block.add_child(n)
         return block
 
     def process(self) -> None:
@@ -1760,3 +1795,8 @@ def split_return_args(s):
 
 def indent(s: str) -> str:
     return textwrap.indent(s, "    ")
+
+
+def is_exit_statement(node):
+    if isinstance(node, (Exit, Switch, Jump)):
+        return True

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -644,6 +644,11 @@ class Block(Statement):
         while True:
             if compiler.peek() == "end":
                 compiler.consume_line()
+                if exit_statement is None:
+                    raise ParseError(
+                        f"Unexpected end of block at line {compiler.line_no}."
+                        + " Blocks must end with an exit statement (e.g. exit, switch, jump)"
+                    )
                 break
 
             n = Statement.consume(compiler, block)
@@ -657,7 +662,7 @@ class Block(Statement):
                 if isinstance(n, (Func, Block)):
                     raise ParseError(
                         f"Unexpected {n} definition at line {n.line_no}. "
-                        + "Block and Function definitions must occur after an exit statement (e.g Exit, switch, jump)."
+                        + "Block and Function definitions must occur after an exit statement (e.g. exit, switch, jump)."
                     )
             if is_exit_statement(n):
                 exit_statement = n

--- a/tests/everything.teal
+++ b/tests/everything.teal
@@ -465,4 +465,3 @@ store 28 // x
 load 27 // y
 load 28 // x
 retsub
-

--- a/tests/everything.teal
+++ b/tests/everything.teal
@@ -346,6 +346,9 @@ inner_stuff:
 fail:
   // oops()
   callsub __func__oops
+  // exit(1)
+  pushint 1
+  return
 
 // Function with no args or return value
 // func oops():
@@ -462,3 +465,4 @@ store 28 // x
 load 27 // y
 load 28 // x
 retsub
+

--- a/tests/everything.tl
+++ b/tests/everything.tl
@@ -139,6 +139,7 @@ end
 
 block fail:
     oops()
+    exit(1)
 end
 
 # Function with no args or return value

--- a/tests/test.py
+++ b/tests/test.py
@@ -33,6 +33,13 @@ def compile_min(p):
     return min_teal
 
 
+def compile_function_min(p):
+    program = ["exit(1)"] + p
+    teal = compile_lines(program)
+    min_teal = strip_comments(teal)
+    return min_teal[2:]
+
+
 def compile_expression_min(p, **kwargs):
     teal = compile_expression(p, **kwargs)
     min_teal = strip_comments(teal)
@@ -317,7 +324,7 @@ class TestAssert(unittest.TestCase):
 
 class TestFunctionReturn(unittest.TestCase):
     def test_pass(self):
-        compile_lines(
+        compile_function_min(
             [
                 "func f():",
                 "return",
@@ -327,7 +334,7 @@ class TestFunctionReturn(unittest.TestCase):
 
     def test_fail_no_return(self):
         with self.assertRaises(ParseError) as e:
-            compile_lines(
+            compile_function_min(
                 [
                     "func f():",
                     "assert(1)",
@@ -339,7 +346,7 @@ class TestFunctionReturn(unittest.TestCase):
     @expectedFailure
     def test_fail_wrong_sig_1_return(self):
         with self.assertRaises(CompileError) as e:
-            compile_lines(
+            compile_function_min(
                 [
                     "func f():",
                     "return 1",
@@ -353,7 +360,7 @@ class TestFunctionReturn(unittest.TestCase):
     @expectedFailure
     def test_fail_wrong_sig_2_returns(self):
         with self.assertRaises(CompileError) as e:
-            compile_lines(
+            compile_function_min(
                 [
                     "func f() int:",
                     "return 1, 2",
@@ -365,7 +372,7 @@ class TestFunctionReturn(unittest.TestCase):
         )
 
     def test_pass_return_literal(self):
-        compile_lines(
+        compile_function_min(
             [
                 "func f() int:",
                 "return 1",
@@ -374,7 +381,7 @@ class TestFunctionReturn(unittest.TestCase):
         )
 
     def test_pass_return_two_literals(self):
-        compile_lines(
+        compile_function_min(
             [
                 "func f() int, int:",
                 "return 1, 2",
@@ -383,7 +390,7 @@ class TestFunctionReturn(unittest.TestCase):
         )
 
     def test_pass_return_math_expression(self):
-        compile_lines(
+        compile_function_min(
             [
                 "func f() int:",
                 "return 1 + 2",
@@ -392,7 +399,7 @@ class TestFunctionReturn(unittest.TestCase):
         )
 
     def test_pass_return_two_math_expressions(self):
-        compile_lines(
+        compile_function_min(
             [
                 "func f() int, int:",
                 "return 1 + 2, 3 + 1",
@@ -401,7 +408,7 @@ class TestFunctionReturn(unittest.TestCase):
         )
 
     def test_pass_return_bytes_with_comma(self):
-        teal = compile_min(
+        teal = compile_function_min(
             [
                 "func f() bytes:",
                 'return "1,2,3"',
@@ -411,7 +418,7 @@ class TestFunctionReturn(unittest.TestCase):
         self.assertListEqual(teal[1:], ['pushbytes "1,2,3"', "retsub"])
 
     def test_pass_return_two_func_calls(self):
-        teal = compile_min(
+        teal = compile_function_min(
             [
                 "func f() int, int:",
                 "return sqrt(25), exp(5, 2)",
@@ -1261,6 +1268,72 @@ class TestPseudoOp(unittest.TestCase):
             ]
         )
         self.assertListEqual(teal, ['method "name(uint64,uint64)"', "log"])
+
+
+class TestExits(unittest.TestCase):
+    def test_pass_nested_blocks(self):
+        compile_min(
+            [
+                "jump a",
+                "block a:",
+                "   jump b",
+                "   block b:",
+                "       exit(1)",
+                "   end",
+                "end",
+            ]
+        )
+
+    def test_pass_comments_after_jump(self):
+        compile_min(
+            [
+                "jump a",
+                "# a comment",
+                "block a:",
+                "   jump b",
+                "   # a comment",
+                "   block b:",
+                "       exit(1)",
+                "   end",
+                "end",
+            ]
+        )
+
+    def test_pass_func_in_block(self):
+        compile_min(
+            [
+                "jump a",
+                "block a:",
+                "   f()",
+                "   exit(1)",
+                "   func f():",
+                "       return",
+                "   end",
+                "end",
+            ]
+        )
+
+    def test_fail_block_before_exit(self):
+        with self.assertRaises(ParseError) as e:
+            compile_min(['log("abc")', "block a:", "   exit(1)", "end"])
+        self.assertIn("Unexpected Block definition", str(e.exception))
+
+    def test_fail_func_before_exit(self):
+        with self.assertRaises(ParseError) as e:
+            compile_min(['log("abc")', "func a():", "   return", "end"])
+        self.assertIn("Unexpected Func definition", str(e.exception))
+
+    def test_fail_block_without_exit(self):
+        with self.assertRaises(ParseError) as e:
+            compile_min(["jump a", "block a:", "   assert(1)", "end"])
+        self.assertIn("Unexpected end of block", str(e.exception))
+
+    def test_fail_block_without_final_exit(self):
+        with self.assertRaises(ParseError) as e:
+            compile_min(
+                ["jump a", "block a:", "   if 1:", "       exit(1)", "   end", "end"]
+            )
+        self.assertIn("Unexpected end of block", str(e.exception))
 
 
 class TestEverythingProgram(unittest.TestCase):


### PR DESCRIPTION
It's currently possible to write code like this:
```
#pragma version 8

switch Txn.ApplicationArgs[0]:
    "main": main
    "foo": foo
end

block main:
    log("main")
end

block foo:
    log("foo")
    exit(1)
end
```

The `main` block has no `exit`,(or `jump` or `switch`) so execution 'falls through' to the `foo` block which is really unexpected.

Now this code will fail to compile with `Unexpected end of block at line 10. Blocks must end with an exit statement (e.g. exit, switch, jump)`


Similarly a program like the following with no 'exit' statement in the outer program should fail to compile:
```
#pragma version 8

log("abc")

block main:
    log("main")
    exit(1)
end

block foo:
    log("foo")
    exit(1)
end
```
This now fails to compile with `Unexpected Block definition at line 5. Block and Function definitions must occur after an exit statement (e.g Exit, switch, jump).`


Finally the following code contains an unreachable statement:
```
#pragma version 8

switch Txn.ApplicationArgs[0]:
    "main": main
    "foo": foo
end

block main:
    log("main")
    exit(1)
end

block foo:
    log("foo")
    exit(1)
end

log("unreachable")
```
This now fails to compile with `Unexpected statement at line 18. Only Block and Function definitions should occur after a Switch.`