### PR TITLE
Remove usage of deprecated importlib.resources functions

### DIFF
--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -240,7 +240,7 @@ class LangSpec:
 
 
 packaged_lang_spec = LangSpec(
-    json.loads(importlib.resources.read_text(package=tealish, resource="langspec.json"))
+    json.loads(importlib.resources.files(tealish).joinpath("langspec.json").read_text())
 )
 packaged_lang_spec.is_packaged = True
 

--- a/tealish/tx_expressions.py
+++ b/tealish/tx_expressions.py
@@ -8,15 +8,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .nodes import Node
 
-with importlib.resources.path(tealish, "tealish_expressions.tx") as p:
-    tealish_mm = metamodel_from_file(
-        p,
-        use_regexp_group=True,
-        skipws=True,
-        ws=" \t",
-        debug=False,
-        classes=class_provider,
-    )
+p = importlib.resources.files(tealish).joinpath("tealish_expressions.tx")
+tealish_mm = metamodel_from_file(
+    p,
+    use_regexp_group=True,
+    skipws=True,
+    ws=" \t",
+    debug=False,
+    classes=class_provider,
+)
 
 
 def parse_expression(source: str) -> "Node":


### PR DESCRIPTION
Reference: https://importlib-resources.readthedocs.io/en/latest/using.html#example